### PR TITLE
fix: use uncompressed public key to sign message

### DIFF
--- a/utils/src/main/java/org/nervos/ckb/crypto/secp256k1/ECKeyPair.java
+++ b/utils/src/main/java/org/nervos/ckb/crypto/secp256k1/ECKeyPair.java
@@ -43,6 +43,10 @@ public class ECKeyPair {
     return new ECKeyPair(privateKeyValue, publicKeyValue);
   }
 
+  public static ECKeyPair createWithPrivateKey(BigInteger privateKey, boolean compressed) {
+    return new ECKeyPair(privateKey, Sign.publicKeyFromPrivate(privateKey, compressed));
+  }
+
   public static ECKeyPair createWithPrivateKey(BigInteger privateKey) {
     return new ECKeyPair(privateKey, Sign.publicKeyFromPrivate(privateKey));
   }

--- a/utils/src/main/java/org/nervos/ckb/crypto/secp256k1/Sign.java
+++ b/utils/src/main/java/org/nervos/ckb/crypto/secp256k1/Sign.java
@@ -194,7 +194,7 @@ public class Sign {
     ECPoint point = publicPointFromPrivate(privKey);
 
     byte[] encoded = point.getEncoded(true);
-    return new BigInteger(1, Arrays.copyOfRange(encoded, 1, encoded.length));
+    return new BigInteger(1, Arrays.copyOfRange(encoded, 0, encoded.length));
   }
 
   /**
@@ -207,7 +207,11 @@ public class Sign {
     ECPoint point = publicPointFromPrivate(privKey);
 
     byte[] encoded = point.getEncoded(compressed);
-    return new BigInteger(1, Arrays.copyOfRange(encoded, 0, encoded.length));
+    if (compressed) {
+      return new BigInteger(1, Arrays.copyOfRange(encoded, 0, encoded.length));
+    } else {
+      return new BigInteger(1, Arrays.copyOfRange(encoded, 1, encoded.length));
+    }
   }
 
   /** Returns public key point from the given private key. */

--- a/utils/src/test/java/org/nervos/ckb/crypto/secp256k1/SignTest.java
+++ b/utils/src/test/java/org/nervos/ckb/crypto/secp256k1/SignTest.java
@@ -16,10 +16,10 @@ public class SignTest {
   @BeforeAll
   public void init() {
     String privateKey = "e79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3";
-    ecKeyPair = ECKeyPair.createWithPrivateKey(Numeric.toBigInt(privateKey));
+    ecKeyPair = ECKeyPair.createWithPrivateKey(Numeric.toBigInt(privateKey), false);
     message =
         Numeric.hexStringToByteArray(
-            "85a1feafb48eae47b88308f525b759d651986e5a4d80a5915cb5d28566d6c7c5");
+            "403676bd85716a1e16b415093cee88c07d7cf2c2199aaf82320d354cb571f0d9");
   }
 
   @Test
@@ -34,8 +34,8 @@ public class SignTest {
   @Test
   public void signMessageTest() {
     String signResult =
-        "0xbe85e76bf2c9ce4042dc9e1d12209ad552e826e83e1e4e8c06198a0fa28de17f5dd2b43723d7f819f26de60ef275d793229fd0b310c393d30584947f811ff37601";
-    String signature = Numeric.toHexString(Sign.signMessage(message, ecKeyPair).getSignature());
+        "0x3045022100c795b2b3c48d370324e5053f4509d4f1f18f80aec4a8cba68ebae922b9f882d8022045ae312bd84e25eed818ef84e7ed61a774f208fe2b2fe3588b60b46860862082";
+    String signature = Numeric.toHexString(Sign.signMessage(message, ecKeyPair).getDerSignature());
     Assertions.assertEquals(signResult, signature);
   }
 


### PR DESCRIPTION
bcprov-jdk15 only stupport uncompressed public key to sign message