### PR TITLE
fix: change getTypeHash to scriptHash

### DIFF
--- a/core/src/main/java/org/nervos/ckb/methods/type/Script.java
+++ b/core/src/main/java/org/nervos/ckb/methods/type/Script.java
@@ -27,7 +27,7 @@ public class Script {
     return new Script(ALWAYS_SUCCESS_HASH, Collections.emptyList());
   }
 
-  public String getTypeHash() {
+  public String scriptHash() {
     Blake2b blake2b = new Blake2b();
     if (codeHash != null) {
       blake2b.update(Numeric.hexStringToByteArray(codeHash));

--- a/core/src/test/java/type/ScriptTest.java
+++ b/core/src/test/java/type/ScriptTest.java
@@ -15,13 +15,13 @@ public class ScriptTest {
   public void testEmptyScriptTypeHash() {
     Script script = new Script(ZERO_HASH, Collections.emptyList());
     Assertions.assertEquals(
-        "0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21", script.getTypeHash());
+        "0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21", script.scriptHash());
   }
 
   @Test
   public void testScriptTypeHash() {
     Script script = new Script(ZERO_HASH, Collections.singletonList("0x01"));
     Assertions.assertEquals(
-        "0xdade0e507e27e2a5995cf39c8cf454b6e70fa80d03c1187db7a4cb2c9eab79da", script.getTypeHash());
+        "0xdade0e507e27e2a5995cf39c8cf454b6e70fa80d03c1187db7a4cb2c9eab79da", script.scriptHash());
   }
 }


### PR DESCRIPTION
objectMapper.writeValueAsString will put getter func into json,so send transaction will have a wrong param "typeHash" in APIServiceImpl