### PR TITLE
[ᚬrc/v0.13.0] chore: witness add non-parameter constructor

### DIFF
--- a/core/src/main/java/org/nervos/ckb/methods/type/Witness.java
+++ b/core/src/main/java/org/nervos/ckb/methods/type/Witness.java
@@ -10,6 +10,8 @@ import org.nervos.ckb.utils.Numeric;
 public class Witness {
   public List<String> data;
 
+  public Witness() {}
+
   public Witness(List<String> data) {
     this.data = data;
   }


### PR DESCRIPTION
fix jackson warning (no suitable constructor found, can not deserialize from Object value)