### PR TITLE
feat: Update address format generator

### DIFF
--- a/utils/src/main/java/org/nervos/ckb/address/AddressUtils.java
+++ b/utils/src/main/java/org/nervos/ckb/address/AddressUtils.java
@@ -13,12 +13,13 @@ import org.nervos.ckb.utils.Numeric;
  * Created by duanyytop on 2019-04-18. Copyright © 2018 Nervos Foundation. All rights reserved.
  *
  * <p>AddressUtils based on CKB Address Format
- * [RFC](https://github.com/nervosnetwork/rfcs/blob/4f87099a0b1a02a8bc077fc7bea15ce3d9def120/rfcs/0000-address-format/0000-address-format.md),
+ * [RFC](https://github.com/nervosnetwork/rfcs/blob/c6b74309e071fd631c12c5f7152a265d7db833f6/rfcs/0000-address-format/0000-address-format.md),
  * and [Common Address Format](https://github.com/nervosnetwork/ckb/wiki/Common-Address-Format).
+ * Currently we implement the predefined format for type 0x01 and code hash index 0x00.
  */
 public class AddressUtils {
   private static final String TYPE = "01";
-  private static final String BIN_IDX = "P2PH";
+  private static final String CODE_HASH_IDX = "00";
 
   private Network network;
 
@@ -31,8 +32,8 @@ public class AddressUtils {
   }
 
   public String generate(String args) throws AddressFormatException {
-    // Payload: type(01) | bin-idx("P2PH") | args
-    String payload = TYPE + strToAscii(BIN_IDX) + Numeric.cleanHexPrefix(args);
+    // Payload: type(01) | code hash index(00, P2PH) | args
+    String payload = TYPE + CODE_HASH_IDX + Numeric.cleanHexPrefix(args);
     byte[] data = Numeric.hexStringToByteArray(payload);
     return Bech32.encode(prefix(), convertBits(Bytes.asList(data), 8, 5, true));
   }
@@ -49,7 +50,7 @@ public class AddressUtils {
   public String getBlake160FromAddress(String address) throws AddressFormatException {
     Bech32.Bech32Data bech32Data = parse(address);
     String payload = Numeric.toHexString(bech32Data.data);
-    String prefix = TYPE + strToAscii(BIN_IDX);
+    String prefix = TYPE + CODE_HASH_IDX;
     String blake160 = payload.replace(prefix, "");
     return blake160;
   }

--- a/utils/src/test/java/org/nervos/ckb/address/AddressTest.java
+++ b/utils/src/test/java/org/nervos/ckb/address/AddressTest.java
@@ -38,7 +38,7 @@ public class AddressTest {
 
   @Test
   public void testArgToAddressTestnet() throws AddressFormatException {
-    String expected = "ckt1q9gry5zg95w42h05rnvm50g0x8c2rt9reu0zjkhltdzxlsz47hacdwv77jds9waehx";
+    String expected = "ckt1qyqz6824th6pekd6858nru9p4j3u783fttl4k3r0cp2lt7uxhx00fxcxpzeq8";
     String args = "0x2d1d555df41cd9ba3d0f31f0a1aca3cf1e295aff5b446fc055f5fb86b99ef49b";
     AddressUtils utils = new AddressUtils(Network.TESTNET);
     String actual = utils.generate(args);
@@ -49,7 +49,7 @@ public class AddressTest {
   public void testPublicKeyHashToAddressTestnet() {
     AddressUtils utils = new AddressUtils(Network.TESTNET);
     Assertions.assertEquals(
-        "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf",
+        "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
         utils.generateFromPublicKey(
             "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"));
   }
@@ -58,7 +58,7 @@ public class AddressTest {
   public void testPublicKeyHashToAddressMainnet() {
     AddressUtils utils = new AddressUtils(Network.MAINNET);
     Assertions.assertEquals(
-        "ckb1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6vqdd7em",
+        "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
         utils.generateFromPublicKey(
             "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"));
   }
@@ -73,15 +73,14 @@ public class AddressTest {
                 true)
             .toString(16);
     Assertions.assertEquals(
-        "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf",
-        utils.generateFromPublicKey(publicKey));
+        "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83", utils.generateFromPublicKey(publicKey));
   }
 
   @Test
   public void testBlake160FromAddressTestnet() {
     AddressUtils utils = new AddressUtils(Network.TESTNET);
     String blake160 =
-        utils.getBlake160FromAddress("ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf");
+        utils.getBlake160FromAddress("ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83");
     Assertions.assertEquals(blake160, "0x36c329ed630d6ce750712a477543672adab57f4c");
   }
 
@@ -89,7 +88,15 @@ public class AddressTest {
   public void testBlake160FromAddressMainnet() {
     AddressUtils utils = new AddressUtils(Network.MAINNET);
     String blake160 =
-        utils.getBlake160FromAddress("ckb1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6vqdd7em");
+        utils.getBlake160FromAddress("ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd");
     Assertions.assertEquals(blake160, "0x36c329ed630d6ce750712a477543672adab57f4c");
+  }
+
+  @Test
+  public void testPubkeyHashToAddressMainnetRFC() {
+    AddressUtils utils = new AddressUtils(Network.MAINNET);
+    Assertions.assertEquals(
+        "ckb1qyqp8eqad7ffy42ezmchkjyz54rhcqf8q9pqrn323p",
+        utils.generate("0x13e41d6F9292555916f17B4882a5477C01270142"));
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: A public key will derive different address from previous implementation.
As the code hash index has been changed from 4 bytes to 1 byte, the first serveral fixed
characters will become ckt1qyq from ckb1q9gry5zg and be shorter.

https://github.com/nervosnetwork/rfcs/pull/100