### PR TITLE
[ᚬmaster] Rc/v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [v0.28.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.27.1...v0.28.0) (2020-2-6)
+# [v0.28.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.27.1...v0.28.0) (2020-2-7)
 
 Bump version to v0.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.28.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.27.1...v0.28.0) (2020-2-6)
+
+Bump version to v0.28.0
+
 # [v0.27.1](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.27.0...v0.27.1) (2020-2-3)
 
 ### Feature

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ allprojects {
     targetCompatibility = 1.8
 
     group 'org.nervos.ckb'
-    version '0.27.1'
+    version '0.28.0'
 
     apply plugin: 'java'
 
@@ -113,7 +113,7 @@ configure(subprojects.findAll { it.name != 'tests' }) {
         publications {
             mavenJava(MavenPublication) {
                 groupId 'org.nervos.ckb'
-                version '0.27.1'
+                version '0.28.0'
                 from components.java
             }
         }


### PR DESCRIPTION
# [v0.28.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.27.1...v0.28.0) (2020-2-7)

Bump version to v0.28.0