### PR TITLE
fix: wrong tx fee

### DIFF
--- a/ckb/src/main/java/org/nervos/ckb/transaction/CellCollector.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/CellCollector.java
@@ -96,7 +96,7 @@ public class CellCollector {
         // update witness of group first element
         int witnessIndex = 0;
         for (String hash : lockHashes) {
-          if (lockInputsMap.get(hash).size() == 0) break;
+          if (lockInputsMap.get(hash).size() == 0) continue;
           witnesses.set(witnessIndex, new Witness(getZeros(initialLength)));
           witnessIndex += lockInputsMap.get(hash).size();
         }


### PR DESCRIPTION
Issue: if there is more than one address and first of the addresses has no live cells, then the witness will be wrong(`0x`), resulting in an error in the calculation of the tx size.