### PR TITLE
fix: witnesses update bug

### DIFF
--- a/ckb/src/main/java/org/nervos/ckb/transaction/CellCollector.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/CellCollector.java
@@ -33,7 +33,7 @@ public class CellCollector {
       Iterator<TransactionInput> iterator)
       throws IOException {
 
-    List<String> lockHashes = new ArrayList<>();
+    Set<String> lockHashes = new LinkedHashSet<>();
     for (String address : addresses) {
       AddressParseResult addressParseResult = AddressParser.parse(address);
       lockHashes.add(addressParseResult.script.computeHash());
@@ -120,10 +120,11 @@ public class CellCollector {
     BigInteger changeCapacity =
         inputsCapacity.subtract(needCapacity.add(calculateTxFee(transaction, feeRate)));
     List<CellsWithAddress> cellsWithAddresses = new ArrayList<>();
+    List<String> lockHashArray = Arrays.asList(lockHashes.toArray(new String[0]));
     for (Map.Entry<String, List<CellInput>> entry : lockInputsMap.entrySet()) {
       cellsWithAddresses.add(
           new CellsWithAddress(
-              entry.getValue(), addresses.get(lockHashes.indexOf(entry.getKey()))));
+              entry.getValue(), addresses.get(lockHashArray.indexOf(entry.getKey()))));
     }
     if (tx.inputs != null && tx.inputs.size() > 0) {
       cellsWithAddresses.get(0).inputs.addAll(0, tx.inputs);

--- a/ckb/src/main/java/org/nervos/ckb/transaction/CellCollector.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/CellCollector.java
@@ -120,11 +120,11 @@ public class CellCollector {
     BigInteger changeCapacity =
         inputsCapacity.subtract(needCapacity.add(calculateTxFee(transaction, feeRate)));
     List<CellsWithAddress> cellsWithAddresses = new ArrayList<>();
-    List<String> lockHashArray = Arrays.asList(lockHashes.toArray(new String[0]));
+    List<String> lockHashList = Arrays.asList(lockHashes.toArray(new String[0]));
     for (Map.Entry<String, List<CellInput>> entry : lockInputsMap.entrySet()) {
       cellsWithAddresses.add(
           new CellsWithAddress(
-              entry.getValue(), addresses.get(lockHashArray.indexOf(entry.getKey()))));
+              entry.getValue(), addresses.get(lockHashList.indexOf(entry.getKey()))));
     }
     if (tx.inputs != null && tx.inputs.size() > 0) {
       cellsWithAddresses.get(0).inputs.addAll(0, tx.inputs);


### PR DESCRIPTION
Issue: When passing multiple same addresses to `collectInputs` will cause `outOfBoundsCheckIndex`