### PR TITLE
Rc/v0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [v0.36.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.35.0...v0.36.0) (2020-09-22)
+# [v0.36.1](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.36.0...v0.36.1) (2020-09-22)
+
+### BugFix
+
+ * Package ckb-sdk.jar with jdk8
+
+
+# [v0.36.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.35.1...v0.36.0) (2020-09-22)
 
 ### Feature
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ allprojects {
     targetCompatibility = 1.8
 
     group 'org.nervos.ckb'
-    version '0.36.0'
+    version '0.36.1'
     apply plugin: 'java'
 
     repositories {
@@ -112,7 +112,7 @@ configure(subprojects.findAll { it.name != 'tests' }) {
         publications {
             mavenJava(MavenPublication) {
                 groupId 'org.nervos.ckb'
-                version '0.36.0'
+                version '0.36.1'
                 from components.java
             }
         }


### PR DESCRIPTION
# [v0.36.1](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.36.0...v0.36.1) (2020-09-22)

### BugFix

 * Package ckb-sdk.jar with jdk8