### PR TITLE
Rc/v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.38.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.37.1...v0.38.0) (2020-11-23)
+
+Bump version to v0.38.0
+
 # [v0.37.1](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.37.0...v0.37.1) (2020-11-10)
 
 ### Feature

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ allprojects {
     targetCompatibility = 1.8
 
     group 'org.nervos.ckb'
-    version '0.37.1'
+    version '0.38.0'
     apply plugin: 'java'
 
     repositories {
@@ -112,7 +112,7 @@ configure(subprojects.findAll { it.name != 'tests' }) {
         publications {
             mavenJava(MavenPublication) {
                 groupId 'org.nervos.ckb'
-                version '0.37.1'
+                version '0.38.0'
                 from components.java
             }
         }


### PR DESCRIPTION
# [v0.38.0](https://github.com/nervosnetwork/ckb-sdk-java/compare/v0.37.1...v0.38.0) (2020-11-23)

Bump version to v0.38.0