### PR TITLE
feat: refactor number type

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ TransactionBuilder txBuilder = new TransactionBuilder(ckbApi);
 IndexerCollector txUtils = new IndexerCollector(ckbApi, ckbIndexerApi);
 
 // Find live cells and calculate capacity balance with the help of CKB indexer.
-BigInteger feeRate = BigInteger.valueOf(1024);
+long feeRate = 1024;
 List<String> SendAddresses = Arrays.asList("ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83");
 CollectResult collectResult = txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
@@ -164,7 +164,7 @@ CollectResult collectResult = txUtils.collectInputs(SendAddresses, txBuilder.bui
 List<CellOutput> cellOutputs = txUtils.generateOutputs(receivers, changeAddress);
 txBuilder.addOutputs(cellOutputs);
 // Charge back (if inputs capacity - fee > outputs capacity)
-if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(BigInteger.ZERO) > 0) {
+if (collectResult.changeCapacity > 0) {
     cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 }

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ CollectResult collectResult = txUtils.collectInputs(SendAddresses, txBuilder.bui
 List<CellOutput> cellOutputs = txUtils.generateOutputs(receivers, changeAddress);
 txBuilder.addOutputs(cellOutputs);
 // Charge back (if inputs capacity - fee > outputs capacity)
-if (collectResult.changeCapacity > 0) {
+if (Long.compareUnsigned(collectResult.changeCapacity, 0) > 0) {
     cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 }

--- a/ckb-api/src/main/java/org/nervos/api/DefaultCkbApi.java
+++ b/ckb-api/src/main/java/org/nervos/api/DefaultCkbApi.java
@@ -62,7 +62,6 @@ import org.nervos.mercury.model.resp.info.DBInfo;
 import org.nervos.mercury.model.resp.info.MercuryInfo;
 import org.nervos.mercury.model.resp.info.MercurySyncState;
 
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class DefaultCkbApi implements CkbApi {
   private CkbRpcApi ckbApi;
 
@@ -145,7 +144,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public Block getBlockByNumber(int blockNumber) throws IOException {
+  public Block getBlockByNumber(long blockNumber) throws IOException {
     return this.ckbApi.getBlockByNumber(blockNumber);
   }
 
@@ -155,7 +154,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public byte[] getBlockHash(int blockNumber) throws IOException {
+  public byte[] getBlockHash(long blockNumber) throws IOException {
     return this.ckbApi.getBlockHash(blockNumber);
   }
 
@@ -175,7 +174,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public BigInteger getTipBlockNumber() throws IOException {
+  public long getTipBlockNumber() throws IOException {
     return this.ckbApi.getTipBlockNumber();
   }
 
@@ -185,7 +184,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public Epoch getEpochByNumber(int epochNumber) throws IOException {
+  public Epoch getEpochByNumber(long epochNumber) throws IOException {
     return this.ckbApi.getEpochByNumber(epochNumber);
   }
 
@@ -195,7 +194,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public Header getHeaderByNumber(int blockNumber) throws IOException {
+  public Header getHeaderByNumber(long blockNumber) throws IOException {
     return this.ckbApi.getHeaderByNumber(blockNumber);
   }
 
@@ -226,7 +225,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public Long getBlockMedianTime(byte[] blockHash) throws IOException {
+  public long getBlockMedianTime(byte[] blockHash) throws IOException {
     return this.ckbApi.getBlockMedianTime(blockHash);
   }
 
@@ -282,7 +281,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public void setNetworkActive(Boolean state) throws IOException {
+  public void setNetworkActive(boolean state) throws IOException {
     this.ckbApi.setNetworkActive(state);
   }
 
@@ -322,7 +321,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public long calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
+  public long calculateDaoMaximumWithdraw(OutPoint outPoint, byte[] withdrawBlockHash)
       throws IOException {
     return this.ckbApi.calculateDaoMaximumWithdraw(outPoint, withdrawBlockHash);
   }

--- a/ckb-api/src/main/java/org/nervos/api/DefaultCkbApi.java
+++ b/ckb-api/src/main/java/org/nervos/api/DefaultCkbApi.java
@@ -322,7 +322,7 @@ public class DefaultCkbApi implements CkbApi {
   }
 
   @Override
-  public BigInteger calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
+  public long calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
       throws IOException {
     return this.ckbApi.calculateDaoMaximumWithdraw(outPoint, withdrawBlockHash);
   }

--- a/ckb-api/src/test/java/org/nervos/api/mercury/BuildSimpleTransferTransactionTest.java
+++ b/ckb-api/src/test/java/org/nervos/api/mercury/BuildSimpleTransferTransactionTest.java
@@ -59,7 +59,7 @@ public class BuildSimpleTransferTransactionTest {
 
     SimpleTransferPayloadBuilder builder = new SimpleTransferPayloadBuilder();
     builder.addFrom(AddressWithKeyHolder.testAddress2());
-    builder.addTo(new ToInfo(AddressWithKeyHolder.testAddress4(), new BigInteger("20")));
+    builder.addTo(new ToInfo(AddressWithKeyHolder.testAddress4(), 20));
     builder.assetInfo(AssetInfo.newUdtAsset(UdtHolder.UDT_HASH));
 
     try {
@@ -84,7 +84,7 @@ public class BuildSimpleTransferTransactionTest {
 
       SimpleTransferPayloadBuilder builder = new SimpleTransferPayloadBuilder();
       builder.addFrom(AddressWithKeyHolder.testAddress2());
-      builder.addTo(new ToInfo(to.address, new BigInteger("20")));
+      builder.addTo(new ToInfo(to.address, 20));
       builder.assetInfo(AssetInfo.newUdtAsset(UdtHolder.UDT_HASH));
 
       TransactionCompletionResponse transactionCompletionResponse =
@@ -104,7 +104,7 @@ public class BuildSimpleTransferTransactionTest {
 
     SimpleTransferPayloadBuilder builder = new SimpleTransferPayloadBuilder();
     builder.addFrom(AddressWithKeyHolder.testAddress4());
-    builder.addTo(new ToInfo(AddressWithKeyHolder.testAddress1(), new BigInteger("20")));
+    builder.addTo(new ToInfo(AddressWithKeyHolder.testAddress1(), 20));
     builder.assetInfo(AssetInfo.newUdtAsset(UdtHolder.UDT_HASH));
 
     try {
@@ -128,7 +128,7 @@ public class BuildSimpleTransferTransactionTest {
     builder.addTo(
         new ToInfo(
             AddressTools.generateAcpAddress(AddressWithKeyHolder.testAddress4()),
-            new BigInteger("20")));
+            20));
     builder.assetInfo(AssetInfo.newUdtAsset(UdtHolder.UDT_HASH));
 
     try {

--- a/ckb-api/src/test/java/org/nervos/api/mercury/ModeTest.java
+++ b/ckb-api/src/test/java/org/nervos/api/mercury/ModeTest.java
@@ -64,7 +64,7 @@ public class ModeTest {
             Source.FREE));
     builder.to(
         To.newTo(
-            Arrays.asList(new ToInfo(AddressWithKeyHolder.testAddress2(), new BigInteger("100"))),
+            Arrays.asList(new ToInfo(AddressWithKeyHolder.testAddress2(), 100)),
             Mode.HOLD_BY_FROM));
 
     try {
@@ -125,7 +125,7 @@ public class ModeTest {
             Arrays.asList(
                 new ToInfo(
                     AddressTools.generateAcpAddress(AddressWithKeyHolder.testAddress4()),
-                    new BigInteger("100"))),
+                    100)),
             Mode.HOLD_BY_TO));
 
     try {

--- a/ckb-api/src/test/java/org/nervos/api/mercury/SourceTest.java
+++ b/ckb-api/src/test/java/org/nervos/api/mercury/SourceTest.java
@@ -82,7 +82,7 @@ public class SourceTest {
 
     builder.to(
         To.newTo(
-            Arrays.asList(new ToInfo(chequeCellReceiverAddress, new BigInteger("100"))),
+            Arrays.asList(new ToInfo(chequeCellReceiverAddress, 100)),
             Mode.HOLD_BY_FROM));
 
     try {
@@ -118,7 +118,7 @@ public class SourceTest {
 
     builder.to(
         To.newTo(
-            Arrays.asList(new ToInfo(receiverAddress, new BigInteger("100"))), Mode.HOLD_BY_FROM));
+            Arrays.asList(new ToInfo(receiverAddress, 100)), Mode.HOLD_BY_FROM));
 
     try {
       TransactionCompletionResponse s =

--- a/ckb-api/src/test/java/org/nervos/api/mercury/TransferCompletionTest.java
+++ b/ckb-api/src/test/java/org/nervos/api/mercury/TransferCompletionTest.java
@@ -181,7 +181,7 @@ public class TransferCompletionTest {
 
     builder.to(
         To.newTo(
-            Arrays.asList(new ToInfo(AddressWithKeyHolder.testAddress2(), new BigInteger("1"))),
+            Arrays.asList(new ToInfo(AddressWithKeyHolder.testAddress2(), 1)),
             Mode.HOLD_BY_TO));
 
     builder.change(AddressWithKeyHolder.testAddress4());

--- a/ckb-indexer/src/main/java/org/nervos/indexer/model/Filter.java
+++ b/ckb-indexer/src/main/java/org/nervos/indexer/model/Filter.java
@@ -1,7 +1,6 @@
 package org.nervos.indexer.model;
 
 import com.google.gson.annotations.SerializedName;
-import java.math.BigInteger;
 import java.util.List;
 import org.nervos.ckb.type.Script;
 
@@ -12,7 +11,7 @@ public class Filter {
   public List<Integer> outputDataLenRange;
 
   @SerializedName("output_capacity_range")
-  public List<BigInteger> outputCapacityRange;
+  public List<Long> outputCapacityRange;
 
   @SerializedName("block_range")
   public List<Integer> blockRange;

--- a/ckb-indexer/src/main/java/org/nervos/indexer/model/SearchKeyBuilder.java
+++ b/ckb-indexer/src/main/java/org/nervos/indexer/model/SearchKeyBuilder.java
@@ -33,7 +33,7 @@ public class SearchKeyBuilder {
     this.filter.outputDataLenRange.add(exclusive);
   }
 
-  public void filterOutputCapacityRange(BigInteger inclusive, BigInteger exclusive) {
+  public void filterOutputCapacityRange(long inclusive, long exclusive) {
     initFilter();
     this.filter.outputCapacityRange = new ArrayList<>(2);
     this.filter.outputCapacityRange.add(inclusive);

--- a/ckb-indexer/src/main/java/org/nervos/indexer/model/resp/CellCapacityResponse.java
+++ b/ckb-indexer/src/main/java/org/nervos/indexer/model/resp/CellCapacityResponse.java
@@ -10,5 +10,5 @@ public class CellCapacityResponse {
   @SerializedName("block_number")
   public int blockNumber;
 
-  public BigInteger capacity;
+  public long capacity;
 }

--- a/ckb-indexer/src/main/java/org/nervos/indexer/model/resp/CellCapacityResponse.java
+++ b/ckb-indexer/src/main/java/org/nervos/indexer/model/resp/CellCapacityResponse.java
@@ -1,7 +1,6 @@
 package org.nervos.indexer.model.resp;
 
 import com.google.gson.annotations.SerializedName;
-import java.math.BigInteger;
 
 public class CellCapacityResponse {
   @SerializedName("block_hash")

--- a/ckb-indexer/src/main/java/org/nervos/indexer/model/resp/OutputResponse.java
+++ b/ckb-indexer/src/main/java/org/nervos/indexer/model/resp/OutputResponse.java
@@ -1,10 +1,9 @@
 package org.nervos.indexer.model.resp;
 
-import java.math.BigInteger;
 import org.nervos.ckb.type.Script;
 
 public class OutputResponse {
-  public BigInteger capacity;
+  public long capacity;
   public Script lock;
   public Script type;
 }

--- a/ckb-indexer/src/test/java/indexer/CapacityTest.java
+++ b/ckb-indexer/src/test/java/indexer/CapacityTest.java
@@ -23,7 +23,6 @@ public class CapacityTest {
             Script.HashType.TYPE));
     key.scriptType(ScriptType.LOCK);
     CellCapacityResponse capacity = CkbIndexerFactory.getApi().getCellsCapacity(key.build());
-    Assertions.assertNotNull(capacity.capacity);
-    Assertions.assertTrue(capacity.capacity.compareTo(BigInteger.ZERO) == 1);
+    Assertions.assertEquals(0, capacity.capacity);
   }
 }

--- a/ckb-indexer/src/test/java/indexer/CapacityTest.java
+++ b/ckb-indexer/src/test/java/indexer/CapacityTest.java
@@ -23,6 +23,6 @@ public class CapacityTest {
             Script.HashType.TYPE));
     key.scriptType(ScriptType.LOCK);
     CellCapacityResponse capacity = CkbIndexerFactory.getApi().getCellsCapacity(key.build());
-    Assertions.assertEquals(0, capacity.capacity);
+    Assertions.assertEquals(1388355000000L, capacity.capacity);
   }
 }

--- a/ckb-indexer/src/test/java/indexer/FilterTest.java
+++ b/ckb-indexer/src/test/java/indexer/FilterTest.java
@@ -31,7 +31,7 @@ public class FilterTest {
             Script.HashType.TYPE));
 
     CellsResponse cells = CkbIndexerFactory.getApi().getCells(key.build(), Order.ASC, 10, null);
-    Assertions.assertNotEquals(0, cells.objects.size());
+    Assertions.assertTrue(cells.objects.size() > 0);
   }
 
   @Test
@@ -47,7 +47,7 @@ public class FilterTest {
     key.filterOutputCapacityRange(0, 1000000000000000000L);
 
     CellsResponse cells = CkbIndexerFactory.getApi().getCells(key.build(), Order.ASC, 10, null);
-    Assertions.assertNotEquals(0, cells.objects.size());
+    Assertions.assertTrue(cells.objects.size() > 0);
   }
 
   @Test

--- a/ckb-indexer/src/test/java/indexer/FilterTest.java
+++ b/ckb-indexer/src/test/java/indexer/FilterTest.java
@@ -44,7 +44,7 @@ public class FilterTest {
             Numeric.hexStringToByteArray("0xe53f35ccf63bb37a3bb0ac3b7f89808077a78eae"),
             Script.HashType.TYPE));
     key.scriptType(ScriptType.LOCK);
-    key.filterOutputCapacityRange(BigInteger.ZERO, new BigInteger("1000000000000000000"));
+    key.filterOutputCapacityRange(0, 1000000000000000000L);
 
     CellsResponse cells = CkbIndexerFactory.getApi().getCells(key.build(), Order.ASC, 10, null);
     Assertions.assertNotEquals(0, cells.objects.size());

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/AdjustAccountPayloadBuilder.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/AdjustAccountPayloadBuilder.java
@@ -31,7 +31,7 @@ public class AdjustAccountPayloadBuilder extends AdjustAccountPayload {
     this.accountNumber = accountNumber;
   }
 
-  public void extraCkb(BigInteger extraCkb) {
+  public void extraCkb(long extraCkb) {
     this.extraCkb = extraCkb;
   }
 

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/DaoDepositPayloadBuilder.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/DaoDepositPayloadBuilder.java
@@ -19,7 +19,7 @@ public class DaoDepositPayloadBuilder extends DaoDepositPayload {
     this.to = to;
   }
 
-  public void amount(BigInteger amount) {
+  public void amount(long amount) {
     this.amount = amount;
   }
 

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/common/Record.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/common/Record.java
@@ -15,9 +15,9 @@ public class Record {
   @SerializedName("ownership")
   public Ownership ownership;
 
-  public BigInteger amount;
+  public long amount;
 
-  public BigInteger occupied;
+  public long occupied;
 
   @SerializedName("asset_info")
   public AssetInfo assetInfo;

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/common/Record.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/common/Record.java
@@ -15,9 +15,9 @@ public class Record {
   @SerializedName("ownership")
   public Ownership ownership;
 
-  public long amount;
+  public BigInteger amount;
 
-  public long occupied;
+  public BigInteger occupied;
 
   @SerializedName("asset_info")
   public AssetInfo assetInfo;

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/req/ToInfo.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/req/ToInfo.java
@@ -4,9 +4,9 @@ import java.math.BigInteger;
 
 public class ToInfo {
   public String address;
-  public BigInteger amount;
+  public long amount;
 
-  public ToInfo(String address, BigInteger amount) {
+  public ToInfo(String address, long amount) {
     this.address = address;
     this.amount = amount;
   }

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/req/payload/AdjustAccountPayload.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/req/payload/AdjustAccountPayload.java
@@ -21,7 +21,7 @@ public class AdjustAccountPayload {
   public BigInteger accountNumber;
 
   @SerializedName("extra_ckb")
-  public BigInteger extraCkb;
+  public long extraCkb;
 
   @SerializedName("fee_rate")
   public BigInteger feeRate;

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/req/payload/DaoDepositPayload.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/req/payload/DaoDepositPayload.java
@@ -12,7 +12,7 @@ public class DaoDepositPayload {
 
   public String to;
 
-  public BigInteger amount;
+  public long amount;
 
   @SerializedName("fee_rate")
   public BigInteger feeRate;

--- a/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/resp/BurnInfo.java
+++ b/ckb-mercury-sdk/src/main/java/org/nervos/mercury/model/resp/BurnInfo.java
@@ -11,5 +11,5 @@ public class BurnInfo {
   @SerializedName("udt_hash")
   public byte[] udtHash;
 
-  public BigInteger amount;
+  public long amount;
 }

--- a/ckb/src/main/java/org/nervos/ckb/CkbRpcApi.java
+++ b/ckb/src/main/java/org/nervos/ckb/CkbRpcApi.java
@@ -101,7 +101,7 @@ public interface CkbRpcApi {
 
   Cycles dryRunTransaction(Transaction transaction) throws IOException;
 
-  BigInteger calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
+  long calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
       throws IOException;
 
   List<RpcResponse> batchRPC(List<List> requests) throws IOException;

--- a/ckb/src/main/java/org/nervos/ckb/CkbRpcApi.java
+++ b/ckb/src/main/java/org/nervos/ckb/CkbRpcApi.java
@@ -1,7 +1,6 @@
 package org.nervos.ckb;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.List;
 import org.nervos.ckb.service.RpcResponse;
 import org.nervos.ckb.type.BannedAddress;
@@ -26,15 +25,14 @@ import org.nervos.ckb.type.param.OutputsValidator;
 import org.nervos.ckb.type.transaction.Transaction;
 import org.nervos.ckb.type.transaction.TransactionWithStatus;
 
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public interface CkbRpcApi {
   Block getBlock(byte[] blockHash) throws IOException;
 
-  Block getBlockByNumber(int blockNumber) throws IOException;
+  Block getBlockByNumber(long blockNumber) throws IOException;
 
   TransactionWithStatus getTransaction(byte[] transactionHash) throws IOException;
 
-  byte[] getBlockHash(int blockNumber) throws IOException;
+  byte[] getBlockHash(long blockNumber) throws IOException;
 
   BlockEconomicState getBlockEconomicState(byte[] blockHash) throws IOException;
 
@@ -42,15 +40,15 @@ public interface CkbRpcApi {
 
   CellWithStatus getLiveCell(OutPoint outPoint, boolean withData) throws IOException;
 
-  BigInteger getTipBlockNumber() throws IOException;
+  long getTipBlockNumber() throws IOException;
 
   Epoch getCurrentEpoch() throws IOException;
 
-  Epoch getEpochByNumber(int epochNumber) throws IOException;
+  Epoch getEpochByNumber(long epochNumber) throws IOException;
 
   Header getHeader(byte[] blockHash) throws IOException;
 
-  Header getHeaderByNumber(int blockNumber) throws IOException;
+  Header getHeaderByNumber(long blockNumber) throws IOException;
 
   TransactionProof getTransactionProof(List<byte[]> txHashes) throws IOException;
 
@@ -62,7 +60,7 @@ public interface CkbRpcApi {
 
   Consensus getConsensus() throws IOException;
 
-  Long getBlockMedianTime(byte[] blockHash) throws IOException;
+  long getBlockMedianTime(byte[] blockHash) throws IOException;
 
   BlockchainInfo getBlockchainInfo() throws IOException;
 
@@ -85,7 +83,7 @@ public interface CkbRpcApi {
 
   SyncState syncState() throws IOException;
 
-  void setNetworkActive(Boolean state) throws IOException;
+  void setNetworkActive(boolean state) throws IOException;
 
   void addNode(String peerId, String address) throws IOException;
 
@@ -101,7 +99,7 @@ public interface CkbRpcApi {
 
   Cycles dryRunTransaction(Transaction transaction) throws IOException;
 
-  long calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
+  long calculateDaoMaximumWithdraw(OutPoint outPoint, byte[] withdrawBlockHash)
       throws IOException;
 
   List<RpcResponse> batchRPC(List<List> requests) throws IOException;

--- a/ckb/src/main/java/org/nervos/ckb/service/Api.java
+++ b/ckb/src/main/java/org/nervos/ckb/service/Api.java
@@ -54,7 +54,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public Block getBlockByNumber(int blockNumber) throws IOException {
+  public Block getBlockByNumber(long blockNumber) throws IOException {
     return rpcService.post(
         "get_block_by_number", Collections.singletonList(blockNumber), Block.class);
   }
@@ -66,7 +66,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public byte[] getBlockHash(int blockNumber) throws IOException {
+  public byte[] getBlockHash(long blockNumber) throws IOException {
     return rpcService.post("get_block_hash", Collections.singletonList(blockNumber), byte[].class);
   }
 
@@ -90,7 +90,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public BigInteger getTipBlockNumber() throws IOException {
+  public long getTipBlockNumber() throws IOException {
     return rpcService.post(
         "get_tip_block_number", Collections.<String>emptyList(), BigInteger.class);
   }
@@ -101,7 +101,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public Epoch getEpochByNumber(int epochNumber) throws IOException {
+  public Epoch getEpochByNumber(long epochNumber) throws IOException {
     return rpcService.post(
         "get_epoch_by_number", Collections.singletonList(epochNumber), Epoch.class);
   }
@@ -112,7 +112,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public Header getHeaderByNumber(int blockNumber) throws IOException {
+  public Header getHeaderByNumber(long blockNumber) throws IOException {
     return rpcService.post(
         "get_header_by_number", Collections.singletonList(blockNumber), Header.class);
   }
@@ -149,7 +149,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public Long getBlockMedianTime(byte[] blockHash) throws IOException {
+  public long getBlockMedianTime(byte[] blockHash) throws IOException {
     return rpcService.post("get_block_median_time", Arrays.asList(blockHash), Long.class);
   }
 
@@ -216,7 +216,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public void setNetworkActive(Boolean state) throws IOException {
+  public void setNetworkActive(boolean state) throws IOException {
     rpcService.post("set_network_active", Collections.singletonList(state), Object.class);
   }
 
@@ -271,7 +271,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public long calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
+  public long calculateDaoMaximumWithdraw(OutPoint outPoint, byte[] withdrawBlockHash)
       throws IOException {
     return rpcService.post(
         "calculate_dao_maximum_withdraw",

--- a/ckb/src/main/java/org/nervos/ckb/service/Api.java
+++ b/ckb/src/main/java/org/nervos/ckb/service/Api.java
@@ -92,7 +92,7 @@ public class Api implements CkbRpcApi {
   @Override
   public long getTipBlockNumber() throws IOException {
     return rpcService.post(
-        "get_tip_block_number", Collections.<String>emptyList(), BigInteger.class);
+        "get_tip_block_number", Collections.<String>emptyList(), Long.class);
   }
 
   @Override
@@ -237,7 +237,7 @@ public class Api implements CkbRpcApi {
         Arrays.asList(
             bannedAddress.address,
             bannedAddress.command,
-            Numeric.toHexStringWithPrefix(BigInteger.valueOf(bannedAddress.banTime)),
+            bannedAddress.banTime,
             bannedAddress.absolute,
             bannedAddress.reason),
         Object.class);

--- a/ckb/src/main/java/org/nervos/ckb/service/Api.java
+++ b/ckb/src/main/java/org/nervos/ckb/service/Api.java
@@ -271,12 +271,12 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public BigInteger calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
+  public long calculateDaoMaximumWithdraw(OutPoint outPoint, String withdrawBlockHash)
       throws IOException {
     return rpcService.post(
         "calculate_dao_maximum_withdraw",
         Arrays.asList(outPoint, withdrawBlockHash),
-        BigInteger.class);
+        Long.class);
   }
 
   /**

--- a/ckb/src/test/java/service/ApiTest.java
+++ b/ckb/src/test/java/service/ApiTest.java
@@ -36,7 +36,6 @@ import org.nervos.ckb.type.param.OutputsValidator;
 import org.nervos.ckb.type.transaction.Transaction;
 import org.nervos.ckb.utils.Numeric;
 
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiTest {
 
@@ -105,9 +104,8 @@ public class ApiTest {
 
   @Test
   public void testGetTipBlockNumber() throws IOException {
-    BigInteger blockNumber = api.getTipBlockNumber();
-    Assertions.assertNotNull(blockNumber);
-    Assertions.assertNotEquals(BigInteger.ZERO, blockNumber);
+    long blockNumber = api.getTipBlockNumber();
+    Assertions.assertNotEquals(0, blockNumber);
   }
 
   @Test
@@ -270,12 +268,12 @@ public class ApiTest {
     RawTxPoolVerbose rawTxPoolVerbose = api.getRawTxPoolVerbose();
     Assertions.assertNotNull(rawTxPoolVerbose);
 
-    for (Map.Entry<String, RawTxPoolVerbose.VerboseDetail> entry :
+    for (Map.Entry<byte[], RawTxPoolVerbose.VerboseDetail> entry :
         rawTxPoolVerbose.pending.entrySet()) {
       Assertions.assertNotNull((entry.getValue()));
     }
 
-    for (Map.Entry<String, RawTxPoolVerbose.VerboseDetail> entry :
+    for (Map.Entry<byte[], RawTxPoolVerbose.VerboseDetail> entry :
         rawTxPoolVerbose.proposed.entrySet()) {
       Assertions.assertNotNull((entry.getValue()));
     }

--- a/ckb/src/test/java/service/ApiTest.java
+++ b/ckb/src/test/java/service/ApiTest.java
@@ -93,7 +93,7 @@ public class ApiTest {
     Assertions.assertEquals(4, transaction.cellDeps.size());
     Assertions.assertEquals(1, transaction.inputs.size());
     Assertions.assertEquals(3, transaction.outputs.size());
-    Assertions.assertEquals(new BigInteger("30000000000"), transaction.outputs.get(0).capacity);
+    Assertions.assertEquals(30000000000L, transaction.outputs.get(0).capacity);
   }
 
   @Test

--- a/ckb/src/test/java/service/ApiTest.java
+++ b/ckb/src/test/java/service/ApiTest.java
@@ -1,7 +1,6 @@
 package service;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +48,6 @@ public class ApiTest {
   @Test
   public void testGetBlockByNumber() throws IOException {
     Block block = api.getBlockByNumber(1);
-    Assertions.assertNotNull(block);
     Assertions.assertEquals(1, block.transactions.size());
   }
 
@@ -67,9 +65,7 @@ public class ApiTest {
         Numeric.hexStringToByteArray(
             "0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd");
     BlockEconomicState blockEconomicState = api.getBlockEconomicState(blockHash);
-    Assertions.assertNotNull(blockEconomicState);
-    Assertions.assertEquals(
-        BigInteger.valueOf(9207601095L), blockEconomicState.minerReward.secondary);
+    Assertions.assertEquals(9207601095L, blockEconomicState.minerReward.secondary);
   }
 
   @Test
@@ -88,7 +84,6 @@ public class ApiTest {
         Numeric.hexStringToByteArray(
             "0x8277d74d33850581f8d843613ded0c2a1722dec0e87e748f45c115dfb14210f1");
     Transaction transaction = api.getTransaction(transactionHash).transaction;
-    Assertions.assertNotNull(transaction);
     Assertions.assertEquals(4, transaction.cellDeps.size());
     Assertions.assertEquals(1, transaction.inputs.size());
     Assertions.assertEquals(3, transaction.outputs.size());
@@ -99,7 +94,7 @@ public class ApiTest {
   public void testGetTipHeader() throws IOException {
     Header header = api.getTipHeader();
     Assertions.assertNotEquals(0, header.number);
-    Assertions.assertNotNull(header.compactTarget);
+    Assertions.assertNotEquals(0, header.compactTarget);
   }
 
   @Test
@@ -112,13 +107,14 @@ public class ApiTest {
   public void testGetCurrentEpoch() throws IOException {
     Epoch epoch = api.getCurrentEpoch();
     Assertions.assertNotEquals(0, epoch.number);
-    Assertions.assertNotNull(epoch.compactTarget);
+    Assertions.assertNotEquals(0, epoch.compactTarget);
   }
 
   @Test
   public void testGetEpochByNumber() throws IOException {
     Epoch epoch = api.getEpochByNumber(2);
     Assertions.assertEquals(1500, epoch.startNumber);
+    Assertions.assertEquals(500945247, epoch.compactTarget);
   }
 
   @Test
@@ -134,7 +130,6 @@ public class ApiTest {
   @Test
   public void testGetHeaderByNumber() throws IOException {
     Header header = api.getHeaderByNumber(1);
-    Assertions.assertNotNull(header);
     Assertions.assertEquals(1, header.number);
     Assertions.assertEquals(1590137711584L, header.timestamp);
   }
@@ -152,7 +147,7 @@ public class ApiTest {
         api.getBlockMedianTime(
             Numeric.hexStringToByteArray(
                 "0xd5ac7cf8c34a975bf258a34f1c2507638487ab71aa4d10a9ec73704aa3abf9cd"));
-    Assertions.assertNotNull(blockMedianTime);
+    Assertions.assertNotEquals(0, blockMedianTime);
     Assertions.assertNotEquals(0, blockMedianTime);
   }
 
@@ -182,7 +177,6 @@ public class ApiTest {
   @Test
   public void testLocalNodeInfo() throws IOException {
     NodeInfo nodeInfo = api.localNodeInfo();
-    Assertions.assertNotNull(nodeInfo);
     Assertions.assertTrue(nodeInfo.addresses.size() > 0);
     Assertions.assertTrue(nodeInfo.protocols.size() > 0);
     Assertions.assertTrue(nodeInfo.protocols.get(0).supportVersions.size() > 0);
@@ -191,17 +185,14 @@ public class ApiTest {
   @Test
   public void testGetPeers() throws IOException {
     List<PeerNodeInfo> peers = api.getPeers();
-    Assertions.assertNotNull(peers);
     Assertions.assertTrue(peers.size() > 0);
     Assertions.assertTrue(peers.get(0).addresses.size() > 0);
     Assertions.assertTrue(peers.get(0).protocols.size() > 0);
-    Assertions.assertNotNull(peers.get(0).protocols.get(0).version);
   }
 
   @Test
   public void testSyncState() throws IOException {
     SyncState state = api.syncState();
-    Assertions.assertNotNull(state);
     Assertions.assertNotEquals(0, state.bestKnownBlockNumber);
   }
 

--- a/core/src/main/java/org/nervos/ckb/service/adapter/BigIntegerTypeAdapter.java
+++ b/core/src/main/java/org/nervos/ckb/service/adapter/BigIntegerTypeAdapter.java
@@ -1,6 +1,8 @@
 package org.nervos.ckb.service.adapter;
 
 import com.google.gson.*;
+import org.nervos.ckb.utils.Numeric;
+
 import java.lang.reflect.Type;
 import java.math.BigInteger;
 

--- a/core/src/main/java/org/nervos/ckb/service/adapter/IntegerTypeAdapter.java
+++ b/core/src/main/java/org/nervos/ckb/service/adapter/IntegerTypeAdapter.java
@@ -8,14 +8,7 @@ public class IntegerTypeAdapter implements JsonSerializer<Integer>, JsonDeserial
 
   @Override
   public JsonElement serialize(Integer src, Type typeOfSrc, JsonSerializationContext context) {
-    String hexValue;
-    // serialize -1 to 0xffffffff for outpoint index in coinbase transaction
-    if (src == -1) {
-      hexValue = "ffffffff";
-    } else {
-      hexValue = Integer.toHexString(src);
-    }
-    return new JsonPrimitive("0x" + hexValue);
+    return new JsonPrimitive("0x" + Integer.toHexString(src));
   }
 
   @Override
@@ -25,11 +18,6 @@ public class IntegerTypeAdapter implements JsonSerializer<Integer>, JsonDeserial
       return json.getAsInt();
     }
     String hexValue = json.getAsString().substring(2);
-    // deserialize 0xffffffff to -1 for outpoint index in coinbase transaction
-    if (Objects.equals("ffffffff", hexValue)) {
-      return -1;
-    } else {
-      return Integer.valueOf(hexValue, 16);
-    }
+    return Integer.parseUnsignedInt(hexValue, 16);
   }
 }

--- a/core/src/main/java/org/nervos/ckb/service/adapter/LongTypeAdapter.java
+++ b/core/src/main/java/org/nervos/ckb/service/adapter/LongTypeAdapter.java
@@ -17,6 +17,6 @@ public class LongTypeAdapter implements JsonDeserializer<Long>, JsonSerializer<L
       return json.getAsLong();
     }
     String hexValue = json.getAsString().substring(2);
-    return Long.valueOf(hexValue, 16);
+    return Long.parseUnsignedLong(hexValue, 16);
   }
 }

--- a/core/src/main/java/org/nervos/ckb/transaction/CollectResult.java
+++ b/core/src/main/java/org/nervos/ckb/transaction/CollectResult.java
@@ -5,9 +5,9 @@ import java.util.List;
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class CollectResult {
   public List<CellsWithAddress> cellsWithAddresses;
-  public String changeCapacity;
+  public long changeCapacity;
 
-  public CollectResult(List<CellsWithAddress> cellsWithAddresses, String changeCapacity) {
+  public CollectResult(List<CellsWithAddress> cellsWithAddresses, long changeCapacity) {
     this.cellsWithAddresses = cellsWithAddresses;
     this.changeCapacity = changeCapacity;
   }

--- a/core/src/main/java/org/nervos/ckb/transaction/TransactionInput.java
+++ b/core/src/main/java/org/nervos/ckb/transaction/TransactionInput.java
@@ -7,10 +7,10 @@ import org.nervos.ckb.type.cell.CellInput;
 public class TransactionInput {
 
   public CellInput input;
-  public BigInteger capacity;
+  public long capacity;
   public String lockHash;
 
-  public TransactionInput(CellInput input, BigInteger capacity, String lockHash) {
+  public TransactionInput(CellInput input, long capacity, String lockHash) {
     this.input = input;
     this.capacity = capacity;
     this.lockHash = lockHash;

--- a/core/src/main/java/org/nervos/ckb/type/AlertMessage.java
+++ b/core/src/main/java/org/nervos/ckb/type/AlertMessage.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class AlertMessage {
-  public String id;
+  public int id;
   public int priority;
 
   @SerializedName("notice_until")

--- a/core/src/main/java/org/nervos/ckb/type/BannedAddress.java
+++ b/core/src/main/java/org/nervos/ckb/type/BannedAddress.java
@@ -2,12 +2,9 @@ package org.nervos.ckb.type;
 
 import com.google.gson.annotations.SerializedName;
 
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class BannedAddress {
   public String address;
   public Command command;
-
-  @SerializedName("ban_time")
   public long banTime;
 
   public boolean absolute;

--- a/core/src/main/java/org/nervos/ckb/type/BannedResultAddress.java
+++ b/core/src/main/java/org/nervos/ckb/type/BannedResultAddress.java
@@ -1,18 +1,8 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
-
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class BannedResultAddress {
-
   public String address;
-
-  @SerializedName("ban_reason")
-  public String banReason;
-
-  @SerializedName("ban_until")
   public long banUntil;
-
-  @SerializedName("created_at")
+  public String banReason;
   public long createdAt;
 }

--- a/core/src/main/java/org/nervos/ckb/type/BlockEconomicState.java
+++ b/core/src/main/java/org/nervos/ckb/type/BlockEconomicState.java
@@ -1,31 +1,22 @@
 package org.nervos.ckb.type;
 
 import com.google.gson.annotations.SerializedName;
-import java.math.BigInteger;
 
-/** Copyright © 2020 Nervos Foundation. All rights reserved. */
 public class BlockEconomicState {
-
-  @SerializedName("finalized_at")
   public byte[] finalizedAt;
-
   public Issuance issuance;
-
-  @SerializedName("miner_reward")
   public MinerReward minerReward;
-
-  @SerializedName("txs_fee")
-  public BigInteger txsFee;
+  public long txsFee;
 
   public static class Issuance {
-    public BigInteger primary;
-    public BigInteger secondary;
+    public long primary;
+    public long secondary;
   }
 
   public static class MinerReward {
-    public BigInteger committed;
-    public BigInteger primary;
-    public BigInteger proposal;
-    public BigInteger secondary;
+    public long committed;
+    public long primary;
+    public long proposal;
+    public long secondary;
   }
 }

--- a/core/src/main/java/org/nervos/ckb/type/BlockchainInfo.java
+++ b/core/src/main/java/org/nervos/ckb/type/BlockchainInfo.java
@@ -1,21 +1,12 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.List;
 
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class BlockchainInfo {
-
-  @SerializedName("is_initial_block_download")
   public boolean isInitialBlockDownload;
-
-  public byte[] epoch;
+  public long epoch;
   public byte[] difficulty;
-
-  @SerializedName("median_time")
   public long medianTime;
-
   public String chain;
-
   public List<AlertMessage> alerts;
 }

--- a/core/src/main/java/org/nervos/ckb/type/Consensus.java
+++ b/core/src/main/java/org/nervos/ckb/type/Consensus.java
@@ -1,82 +1,46 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
 import java.math.BigInteger;
+import java.util.List;
 
-/** Copyright © 2021 Nervos Foundation. All rights reserved. */
 public class Consensus {
-  @SerializedName("block_version")
   public int blockVersion;
-
-  @SerializedName("cellbase_maturity")
-  public byte[] cellbaseMaturity;
-
-  @SerializedName("dao_type_hash")
+  public long cellbaseMaturity;
   public byte[] daoTypeHash;
-
-  @SerializedName("epoch_duration_target")
-  public byte[] epochDurationTarget;
-
-  @SerializedName("genesis_hash")
+  public long epochDurationTarget;
   public byte[] genesisHash;
-
   public String id;
-
-  @SerializedName("initial_primary_epoch_reward")
-  public BigInteger initialPrimaryEpochReward;
-
-  @SerializedName("max_block_bytes")
-  public int maxBlockBytes;
-
-  @SerializedName("max_block_cycles")
+  public long initialPrimaryEpochReward;
+  public long maxBlockBytes;
   public long maxBlockCycles;
-
-  @SerializedName("max_block_proposals_limit")
-  public int maxBlockProposalsLimit;
-
-  @SerializedName("max_uncles_num")
-  public int maxUnclesNum;
-
-  @SerializedName("median_time_block_count")
-  public int medianTimeBlockCount;
-
-  @SerializedName("orphan_rate_target")
+  public long maxBlockProposalsLimit;
+  public long maxUnclesNum;
+  public long medianTimeBlockCount;
   public Ratio orphanRateTarget;
-
-  @SerializedName("permanent_difficulty_in_dummy")
   public boolean permanentDifficultyInDummy;
-
-  @SerializedName("primary_epoch_reward_halving_interval")
-  public int primaryEpochRewardHalvingInterval;
-
-  @SerializedName("proposer_reward_ratio")
+  public long primaryEpochRewardHalvingInterval;
   public Ratio proposerRewardRatio;
-
-  @SerializedName("secondary_epoch_reward")
-  public BigInteger secondaryEpochReward;
-
-  @SerializedName("secp256k1_blake160_multisig_all_type_hash")
+  public long secondaryEpochReward;
   public byte[] secp256k1Blake160MultisigAllTypeHash;
-
-  @SerializedName("secp256k1_blake160_sighash_all_type_hash")
   public byte[] secp256k1Blake160SighashAllTypeHash;
-
-  @SerializedName("tx_proposal_window")
   public TxProposalWindow txProposalWindow;
-
-  @SerializedName("tx_version")
   public int txVersion;
-
-  @SerializedName("type_id_code_hash")
   public byte[] typeIdCodeHash;
+  public List<HardForkFeature> hardForkFeatures;
 
   public static class Ratio {
-    public int denom;
-    public int numer;
+    public BigInteger denom;
+    public BigInteger numer;
   }
 
   public static class TxProposalWindow {
-    public int closest;
-    public int farthest;
+    public long closest;
+    public long farthest;
   }
+
+  public static class HardForkFeature {
+    public String id;
+    public long epochNumber;
+  }
+
 }

--- a/core/src/main/java/org/nervos/ckb/type/Cycles.java
+++ b/core/src/main/java/org/nervos/ckb/type/Cycles.java
@@ -1,7 +1,5 @@
 package org.nervos.ckb.type;
 
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class Cycles {
-
-  public int cycles;
+  public long cycles;
 }

--- a/core/src/main/java/org/nervos/ckb/type/Epoch.java
+++ b/core/src/main/java/org/nervos/ckb/type/Epoch.java
@@ -1,18 +1,8 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
-
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class Epoch {
-  public int number;
-
-  @SerializedName("start_number")
-  public int startNumber;
-
-  public int length;
-
-  @SerializedName("compact_target")
-  public byte[] compactTarget;
-
-  public Epoch() {}
+  public long number;
+  public long startNumber;
+  public long length;
+  public int compactTarget;
 }

--- a/core/src/main/java/org/nervos/ckb/type/Header.java
+++ b/core/src/main/java/org/nervos/ckb/type/Header.java
@@ -2,34 +2,20 @@ package org.nervos.ckb.type;
 
 import static org.nervos.ckb.utils.MoleculeConverter.packUint128;
 
-import com.google.gson.annotations.SerializedName;
 import java.math.BigInteger;
 
 public class Header {
-
   public byte[] dao;
   public byte[] hash;
   public BigInteger nonce;
   public int number;
   public BigInteger epoch;
-
-  @SerializedName("compact_target")
-  public long compactTarget;
-
-  @SerializedName("parent_hash")
+  public int compactTarget;
   public byte[] parentHash;
-
   public long timestamp;
-
-  @SerializedName("transactions_root")
   public byte[] transactionsRoot;
-
-  @SerializedName("proposals_hash")
   public byte[] proposalsHash;
-
-  @SerializedName("extra_hash")
   public byte[] extraHash;
-
   public int version;
 
   public RawHeader getRawHeader() {

--- a/core/src/main/java/org/nervos/ckb/type/Header.java
+++ b/core/src/main/java/org/nervos/ckb/type/Header.java
@@ -8,8 +8,8 @@ public class Header {
   public byte[] dao;
   public byte[] hash;
   public BigInteger nonce;
-  public int number;
-  public BigInteger epoch;
+  public long number;
+  public long epoch;
   public int compactTarget;
   public byte[] parentHash;
   public long timestamp;

--- a/core/src/main/java/org/nervos/ckb/type/NodeInfo.java
+++ b/core/src/main/java/org/nervos/ckb/type/NodeInfo.java
@@ -1,18 +1,11 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.List;
 
-/** Copyright © 2018 Nervos Foundation. All rights reserved. */
 public class NodeInfo {
-
-  @SerializedName("node_id")
   public String nodeId;
-
   public boolean active;
-
-  @SerializedName("connections")
-  public int connections;
+  public long connections;
 
   public String version;
   public List<Address> addresses;
@@ -20,14 +13,12 @@ public class NodeInfo {
 
   public static class Address {
     public String address;
-    public int score;
+    public long score;
   }
 
   public static class Protocol {
-    public int id;
+    public long id;
     public String name;
-
-    @SerializedName("support_versions")
     public List<String> supportVersions;
   }
 }

--- a/core/src/main/java/org/nervos/ckb/type/PeerNodeInfo.java
+++ b/core/src/main/java/org/nervos/ckb/type/PeerNodeInfo.java
@@ -1,60 +1,35 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.List;
 
-/** Copyright © 2018 Nervos Foundation. All rights reserved. */
 public class PeerNodeInfo {
-
-  @SerializedName("node_id")
   public String nodeId;
-
-  @SerializedName("connected_duration")
   public long connectedDuration;
-
-  @SerializedName("is_outbound")
   public boolean isOutbound;
-
-  @SerializedName("last_ping_duration")
   public long lastPingDuration;
-
   public String version;
   public List<Address> addresses;
   public List<Protocol> protocols;
-
-  @SerializedName("sync_state")
   public SyncState syncState;
 
   public static class Address {
     public String address;
-    public int score;
+    public long score;
   }
 
   public static class Protocol {
-    public int id;
+    public long id;
     public String version;
   }
 
   public static class SyncState {
-    @SerializedName("best_known_header_hash")
-    public String BEST_KNOWN_HEADER;
-
-    @SerializedName("best_known_header_number")
-    public String BEST_KNOWN_HEADER_NUMBER;
-
-    @SerializedName("can_fetch_count")
-    public String CAN_FETCH_COUNT;
-
-    @SerializedName("inflight_count")
-    public String INFLIGHT_COUNT;
-
-    @SerializedName("last_common_header_hash")
-    public String LAST_COMMON_HEADER_HASH;
-
-    @SerializedName("last_common_header_number")
-    public String LAST_COMMON_HEADER_NUMBER;
-
-    @SerializedName("unknown_header_list_size")
-    public String UNKNOWN_HEADER_LIST_SIZE;
+    public byte[] bestKnownHeaderHash;
+    public long bestKnownHeaderNumber;
+    public byte[] lastCommonHeaderHash;
+    public long lastCommonHeaderNumber;
+    @Deprecated
+    public long unknownHeaderListSize;
+    public long inflightCount;
+    public long canFetchCount;
   }
 }

--- a/core/src/main/java/org/nervos/ckb/type/RawHeader.java
+++ b/core/src/main/java/org/nervos/ckb/type/RawHeader.java
@@ -2,13 +2,11 @@ package org.nervos.ckb.type;
 
 import static org.nervos.ckb.utils.MoleculeConverter.*;
 
-import java.math.BigInteger;
-
 public class RawHeader {
   public byte[] dao;
   public byte[] hash;
-  public int number;
-  public BigInteger epoch;
+  public long number;
+  public long epoch;
   public int compactTarget;
   public byte[] parentHash;
   public long timestamp;

--- a/core/src/main/java/org/nervos/ckb/type/RawHeader.java
+++ b/core/src/main/java/org/nervos/ckb/type/RawHeader.java
@@ -9,7 +9,7 @@ public class RawHeader {
   public byte[] hash;
   public int number;
   public BigInteger epoch;
-  public long compactTarget;
+  public int compactTarget;
   public byte[] parentHash;
   public long timestamp;
   public byte[] transactionsRoot;

--- a/core/src/main/java/org/nervos/ckb/type/RawTxPool.java
+++ b/core/src/main/java/org/nervos/ckb/type/RawTxPool.java
@@ -2,8 +2,7 @@ package org.nervos.ckb.type;
 
 import java.util.List;
 
-/** Copyright © 2021 Nervos Foundation. All rights reserved. */
 public class RawTxPool {
-  public List<String> pending;
-  public List<String> proposed;
+  public List<byte[]> pending;
+  public List<byte[]> proposed;
 }

--- a/core/src/main/java/org/nervos/ckb/type/RawTxPoolVerbose.java
+++ b/core/src/main/java/org/nervos/ckb/type/RawTxPoolVerbose.java
@@ -1,25 +1,17 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.Map;
 
-/** Copyright © 2021 Nervos Foundation. All rights reserved. */
 public class RawTxPoolVerbose {
-  public Map<String, VerboseDetail> pending;
-  public Map<String, VerboseDetail> proposed;
+  public Map<byte[], VerboseDetail> pending;
+  public Map<byte[], VerboseDetail> proposed;
 
   public static class VerboseDetail {
-    public String cycles;
-    public String size;
-    public String fee;
-
-    @SerializedName("ancestors_size")
-    public String ancestorsSize;
-
-    @SerializedName("ancestors_cycles")
-    public String ancestorsCycles;
-
-    @SerializedName("ancestors_count")
-    public String ancestorsCount;
+    public long cycles;
+    public long size;
+    public long fee;
+    public long ancestorsSize;
+    public long ancestorsCycles;
+    public long ancestorsCount;
   }
 }

--- a/core/src/main/java/org/nervos/ckb/type/Script.java
+++ b/core/src/main/java/org/nervos/ckb/type/Script.java
@@ -35,7 +35,7 @@ public class Script {
     return blake2b.doFinalBytes();
   }
 
-  public BigInteger occupiedCapacity() {
+  public long occupiedCapacity() {
     int byteSize = 1;
     if (codeHash != null) {
       byteSize += codeHash.length;

--- a/core/src/main/java/org/nervos/ckb/type/SyncState.java
+++ b/core/src/main/java/org/nervos/ckb/type/SyncState.java
@@ -1,28 +1,12 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
-
 public class SyncState {
-  @SerializedName("best_known_block_number")
-  public int bestKnownBlockNumber;
-
-  @SerializedName("best_known_block_timestamp")
-  public long bestKnownBlockTimestamp;
-
-  @SerializedName("fast_time")
-  public long fastTime;
-
   public boolean ibd;
-
-  @SerializedName("inflight_blocks_count")
-  public int inflightBlocksCount;
-
-  @SerializedName("low_time")
-  public long lowTime;
-
-  @SerializedName("normal_time")
+  public long bestKnownBlockNumber;
+  public long bestKnownBlockTimestamp;
+  public long orphanBlocksCount;
+  public long inflightBlocksCount;
+  public long fastTime;
   public long normalTime;
-
-  @SerializedName("orphan_blocks_count")
-  public int orphanBlocksCount;
+  public long lowTime;
 }

--- a/core/src/main/java/org/nervos/ckb/type/TxPoolInfo.java
+++ b/core/src/main/java/org/nervos/ckb/type/TxPoolInfo.java
@@ -1,30 +1,13 @@
 package org.nervos.ckb.type;
 
-import com.google.gson.annotations.SerializedName;
-import java.math.BigInteger;
-
-/** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class TxPoolInfo {
-
-  public int orphan;
-  public int pending;
-  public int proposed;
-
-  @SerializedName("last_txs_updated_at")
+  public long orphan;
+  public long pending;
+  public long proposed;
   public long lastTxsUpdatedAt;
-
-  @SerializedName("total_tx_cycles")
   public long totalTxCycles;
-
-  @SerializedName("total_tx_size")
-  public int totalTxSize;
-
-  @SerializedName("min_fee_rate")
-  public BigInteger minFeeRate;
-
-  @SerializedName("tip_hash")
+  public long totalTxSize;
+  public long minFeeRate;
   public byte[] tipHash;
-
-  @SerializedName("tip_number")
-  public int tipNumber;
+  public long tipNumber;
 }

--- a/core/src/main/java/org/nervos/ckb/type/cell/CellInput.java
+++ b/core/src/main/java/org/nervos/ckb/type/cell/CellInput.java
@@ -2,26 +2,21 @@ package org.nervos.ckb.type.cell;
 
 import static org.nervos.ckb.utils.MoleculeConverter.packUint64;
 
-import com.google.gson.annotations.SerializedName;
-import java.math.BigInteger;
 import org.nervos.ckb.type.OutPoint;
 
 public class CellInput {
-
-  @SerializedName("previous_output")
   public OutPoint previousOutput;
-
-  public BigInteger since;
+  public long since;
 
   public CellInput() {}
 
-  public CellInput(OutPoint previousOutput, BigInteger since) {
+  public CellInput(OutPoint previousOutput, long since) {
     this.previousOutput = previousOutput;
     this.since = since;
   }
 
   public CellInput(OutPoint previousOutput) {
-    this(previousOutput, BigInteger.ZERO);
+    this(previousOutput, 0);
   }
 
   public org.nervos.ckb.newtype.concrete.CellInput pack() {

--- a/core/src/main/java/org/nervos/ckb/type/cell/CellOutput.java
+++ b/core/src/main/java/org/nervos/ckb/type/cell/CellOutput.java
@@ -30,10 +30,10 @@ public class CellOutput {
       byteSize += Utils.ckbToShannon(data.length);
     }
     if (lock != null) {
-      byteSize += Utils.ckbToShannon(lock.occupiedCapacity());
+      byteSize += lock.occupiedCapacity();
     }
     if (type != null) {
-      byteSize += Utils.ckbToShannon(type.occupiedCapacity());
+      byteSize += type.occupiedCapacity();
     }
     return byteSize;
   }

--- a/core/src/main/java/org/nervos/ckb/type/cell/CellOutput.java
+++ b/core/src/main/java/org/nervos/ckb/type/cell/CellOutput.java
@@ -7,33 +7,33 @@ import org.nervos.ckb.type.Script;
 import org.nervos.ckb.utils.Utils;
 
 public class CellOutput {
-  public BigInteger capacity;
+  public long capacity;
   public Script type;
   public Script lock;
 
   public CellOutput() {}
 
-  public CellOutput(BigInteger capacity, Script lock) {
+  public CellOutput(long capacity, Script lock) {
     this.capacity = capacity;
     this.lock = lock;
   }
 
-  public CellOutput(BigInteger capacity, Script lock, Script type) {
+  public CellOutput(long capacity, Script lock, Script type) {
     this.capacity = capacity;
     this.lock = lock;
     this.type = type;
   }
 
-  public BigInteger occupiedCapacity(byte[] data) {
-    BigInteger byteSize = Utils.ckbToShannon(8);
+  public long occupiedCapacity(byte[] data) {
+    long byteSize = Utils.ckbToShannon(8);
     if (data != null) {
-      byteSize = byteSize.add(Utils.ckbToShannon(data.length));
+      byteSize += Utils.ckbToShannon(data.length);
     }
     if (lock != null) {
-      byteSize = byteSize.add(lock.occupiedCapacity());
+      byteSize += Utils.ckbToShannon(lock.occupiedCapacity());
     }
     if (type != null) {
-      byteSize = byteSize.add(type.occupiedCapacity());
+      byteSize += Utils.ckbToShannon(type.occupiedCapacity());
     }
     return byteSize;
   }

--- a/core/src/main/java/org/nervos/ckb/type/transaction/Transaction.java
+++ b/core/src/main/java/org/nervos/ckb/type/transaction/Transaction.java
@@ -237,7 +237,7 @@ public class Transaction {
     }
 
     public Builder addOutput(
-        BigInteger capacity,
+        long capacity,
         byte[] lockScriptCodeHash,
         byte[] lockScriptArgs,
         byte[] typeScriptCodeHash,
@@ -254,7 +254,7 @@ public class Transaction {
     }
 
     public Builder addOutput(
-        BigInteger capacity, byte[] lockScriptCodeHash, byte[] lockScriptArgs) {
+        long capacity, byte[] lockScriptCodeHash, byte[] lockScriptArgs) {
       Script lockScript = new Script();
       lockScript.args = lockScriptArgs;
       lockScript.codeHash = lockScriptCodeHash;

--- a/core/src/main/java/org/nervos/ckb/type/transaction/Transaction.java
+++ b/core/src/main/java/org/nervos/ckb/type/transaction/Transaction.java
@@ -14,23 +14,13 @@ import org.nervos.ckb.type.cell.CellInput;
 import org.nervos.ckb.type.cell.CellOutput;
 
 public class Transaction {
-
   public int version;
-
   public byte[] hash;
-
-  @SerializedName("cell_deps")
   public List<CellDep> cellDeps;
-
-  @SerializedName("header_deps")
   public List<byte[]> headerDeps;
-
   public List<CellInput> inputs;
   public List<CellOutput> outputs;
-
-  @SerializedName("outputs_data")
   public List<byte[]> outputsData;
-
   public List<byte[]> witnesses;
 
   public Transaction() {}

--- a/core/src/main/java/org/nervos/ckb/type/transaction/Transaction.java
+++ b/core/src/main/java/org/nervos/ckb/type/transaction/Transaction.java
@@ -2,7 +2,6 @@ package org.nervos.ckb.type.transaction;
 
 import static org.nervos.ckb.utils.MoleculeConverter.packBytesVec;
 
-import com.google.gson.annotations.SerializedName;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -217,10 +216,10 @@ public class Transaction {
     }
 
     public Builder addInput(byte[] txHash, int index) {
-      return this.addInput(txHash, index, BigInteger.ZERO);
+      return this.addInput(txHash, index, 0);
     }
 
-    public Builder addInput(byte[] txHash, int index, BigInteger since) {
+    public Builder addInput(byte[] txHash, int index, long since) {
       CellInput input = new CellInput();
       input.previousOutput = new OutPoint(txHash, index);
       input.since = since;

--- a/core/src/main/java/org/nervos/ckb/utils/AmountUtils.java
+++ b/core/src/main/java/org/nervos/ckb/utils/AmountUtils.java
@@ -3,15 +3,11 @@ package org.nervos.ckb.utils;
 import java.math.BigInteger;
 
 public class AmountUtils {
-  public static BigInteger ckbToShannon(BigInteger value) {
+  public static long ckbToShannon(long value) {
     return Utils.ckbToShannon(value);
   }
 
-  public static BigInteger ckbToShannon(long value) {
-    return Utils.ckbToShannon(value);
-  }
-
-  public static BigInteger ckbToShannon(double value) {
+  public static long ckbToShannon(double value) {
     return Utils.ckbToShannon(value);
   }
 }

--- a/core/src/main/java/org/nervos/ckb/utils/Calculator.java
+++ b/core/src/main/java/org/nervos/ckb/utils/Calculator.java
@@ -19,8 +19,8 @@ public class Calculator {
 
   private static long calculateTransactionFee(long transactionSize, long feeRate) {
     long base = transactionSize * feeRate;
-    long fee = base / RADIO;
-    if (fee * feeRate < base) {
+    long fee = Long.divideUnsigned(base, RADIO);
+    if (Long.compareUnsigned(fee * feeRate, base) < 0) {
       return fee + 1;
     }
     return fee;

--- a/core/src/main/java/org/nervos/ckb/utils/Calculator.java
+++ b/core/src/main/java/org/nervos/ckb/utils/Calculator.java
@@ -1,6 +1,8 @@
 package org.nervos.ckb.utils;
 
 import java.math.BigInteger;
+
+import org.nervos.ckb.type.RawHeader;
 import org.nervos.ckb.type.transaction.Transaction;
 
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
@@ -13,20 +15,19 @@ public class Calculator {
     return bytes.length + SERIALIZED_TX_OFFSET_BYTE_SIZE;
   }
 
-  private static final BigInteger RADIO = BigInteger.valueOf(1000);
+  private static final long RADIO = 1000;
 
-  private static BigInteger calculateTransactionFee(
-      BigInteger transactionSize, BigInteger feeRate) {
-    BigInteger base = transactionSize.multiply(feeRate);
-    BigInteger fee = base.divide(RADIO);
-    if (fee.multiply(RADIO).compareTo(base) < 0) {
-      return fee.add(BigInteger.ONE);
+  private static long calculateTransactionFee(long transactionSize, long feeRate) {
+    long base = transactionSize * feeRate;
+    long fee = base / RADIO;
+    if (fee * feeRate < base) {
+      return fee + 1;
     }
     return fee;
   }
 
-  public static BigInteger calculateTransactionFee(Transaction transaction, BigInteger feeRate) {
-    BigInteger txSize = BigInteger.valueOf(calculateTransactionSize(transaction));
+  public static long calculateTransactionFee(Transaction transaction, long feeRate) {
+    long txSize = calculateTransactionSize(transaction);
     return calculateTransactionFee(txSize, feeRate);
   }
 }

--- a/core/src/main/java/org/nervos/ckb/utils/EpochUtils.java
+++ b/core/src/main/java/org/nervos/ckb/utils/EpochUtils.java
@@ -13,6 +13,10 @@ public class EpochUtils {
     return new EpochInfo(length, index, number);
   }
 
+  public static EpochInfo parse(long epoch) {
+    return parse(BigInteger.valueOf(epoch).toByteArray());
+  }
+
   public static String generate(long length, long index, long number) {
     BigInteger epoch = BigInteger.valueOf((length << 40) + (index << 24) + number);
     return Numeric.toHexStringWithPrefix(epoch);

--- a/core/src/main/java/org/nervos/ckb/utils/MoleculeConverter.java
+++ b/core/src/main/java/org/nervos/ckb/utils/MoleculeConverter.java
@@ -14,25 +14,14 @@ public class MoleculeConverter {
     return out;
   }
 
-  // TODO: will be removed after the new type to Uint32 is ready
-  public static Uint32 packUint32(long in) {
-    return packUint32(BigInteger.valueOf(in));
-  }
-
-  // TODO: will be removed after the new type to Uint32 is ready
-  public static Uint32 packUint32(BigInteger in) {
-    byte[] arr = toByteArrayLittleEndianUnsigned(in, Uint32.SIZE);
+  public static Uint32 packUint32(int in) {
+    byte[] arr = toByteArrayLittleEndianUnsigned(BigInteger.valueOf(in), Uint32.SIZE);
     return Uint32.builder(arr).build();
   }
 
-  // TODO: will be removed after the new type to Uint64 is ready
-  public static Uint64 packUint64(BigInteger in) {
-    byte[] arr = toByteArrayLittleEndianUnsigned(in, Uint64.SIZE);
-    return Uint64.builder(arr).build();
-  }
-
   public static Uint64 packUint64(long in) {
-    return packUint64(BigInteger.valueOf(in));
+    byte[] arr = toByteArrayLittleEndianUnsigned(BigInteger.valueOf(in), Uint64.SIZE);
+    return Uint64.builder(arr).build();
   }
 
   public static Uint128 packUint128(BigInteger in) {

--- a/core/src/test/java/type/CellOutputTest.java
+++ b/core/src/test/java/type/CellOutputTest.java
@@ -16,20 +16,19 @@ public class CellOutputTest {
   public void testOccupiedCapacity() {
     CellOutput cellOutput =
         new CellOutput(
-            new BigInteger("100000000000"),
+            100000000000L,
             createScript(
                 "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                 "0x59a27ef3ba84f061517d13f42cf44ed020610061",
                 Script.HashType.TYPE));
-    Assertions.assertEquals(
-        BigInteger.valueOf(6100000000L), cellOutput.occupiedCapacity(new byte[] {}));
+    Assertions.assertEquals(6100000000L, cellOutput.occupiedCapacity(new byte[] {}));
   }
 
   @Test
   public void testOccupiedCapacityWithData() {
     CellOutput cellOutput =
         new CellOutput(
-            new BigInteger("100000000000"),
+            100000000000L,
             createScript(
                 "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                 "0x59a27ef3ba84f061517d13f42cf44ed020610061",

--- a/core/src/test/java/type/CellOutputTest.java
+++ b/core/src/test/java/type/CellOutputTest.java
@@ -33,8 +33,7 @@ public class CellOutputTest {
                 "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                 "0x59a27ef3ba84f061517d13f42cf44ed020610061",
                 Script.HashType.TYPE));
-    Assertions.assertEquals(
-        BigInteger.valueOf(9300000000L),
+    Assertions.assertEquals(9300000000L,
         cellOutput.occupiedCapacity(
             Numeric.hexStringToByteArray(
                 "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88")));

--- a/core/src/test/java/type/ScriptTest.java
+++ b/core/src/test/java/type/ScriptTest.java
@@ -1,7 +1,6 @@
 package type;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.nervos.ckb.crypto.Hash;
@@ -32,6 +31,6 @@ public class ScriptTest {
                 "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"),
             Numeric.hexStringToByteArray("0x36c329ed630d6ce750712a477543672adab57f4c"),
             Script.HashType.TYPE);
-    Assertions.assertEquals(BigInteger.valueOf(5300000000L), script.occupiedCapacity());
+    Assertions.assertEquals(5300000000L, script.occupiedCapacity());
   }
 }

--- a/core/src/test/java/type/TransactionTest.java
+++ b/core/src/test/java/type/TransactionTest.java
@@ -75,8 +75,7 @@ class TransactionTest {
             new OutPoint(
                 Numeric.hexStringToByteArray(
                     "0x91fcfd61f420c1090aeded6b6d91d5920a279fe53ec34353afccc59264eeddd4"),
-                0),
-            BigInteger.valueOf(113)));
+                0), 113));
     cellInputs.add(
         new CellInput(
             new OutPoint(

--- a/core/src/test/java/type/TransactionTest.java
+++ b/core/src/test/java/type/TransactionTest.java
@@ -26,13 +26,13 @@ class TransactionTest {
     List<CellOutput> cellOutputs = new ArrayList<>();
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("100000000000"),
+            100000000000L,
             createScript(
                 "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08",
                 "0xe2193df51d78411601796b35b17b4f8f2cd85bd0")));
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("4900000000000"),
+            4900000000000L,
             createScript(
                 "0xe3b513a2105a5d4f833d1fad3d968b96b4510687234cd909f86b3ac450d8a2b5",
                 "0x36c329ed630d6ce750712a477543672adab57f4c")));
@@ -86,7 +86,7 @@ class TransactionTest {
     List<CellOutput> cellOutputs = new ArrayList<>();
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("10000009045634"),
+            10000009045634l,
             createScript(
                 "0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd",
                 "0x36c329ed630d6ce750712a477543672adab57f4c")));
@@ -128,13 +128,13 @@ class TransactionTest {
     List<CellOutput> cellOutputs = new ArrayList<>();
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("100000000000"),
+            100000000000L,
             createScript(
                 "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08",
                 "0xe2193df51d78411601796b35b17b4f8f2cd85bd0")));
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("4900000000000"),
+            4900000000000L,
             createScript(
                 "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08",
                 "0x36c329ed630d6ce750712a477543672adab57f4c")));
@@ -192,7 +192,7 @@ class TransactionTest {
                         1))),
             Arrays.asList(
                 new CellOutput(
-                    new BigInteger("100000000000"),
+                    100000000000L,
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -202,7 +202,7 @@ class TransactionTest {
                         "0x",
                         Script.HashType.DATA)),
                 new CellOutput(
-                    new BigInteger("98824000000000"),
+                    98824000000000L,
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",

--- a/core/src/test/java/utils/CalculatorTest.java
+++ b/core/src/test/java/utils/CalculatorTest.java
@@ -49,7 +49,7 @@ public class CalculatorTest {
                         1))),
             Arrays.asList(
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -59,7 +59,7 @@ public class CalculatorTest {
                         "0x",
                         Script.HashType.DATA)),
                 new CellOutput(
-                    Numeric.toBigInt("0x59e1416a5000"),
+                    Long.valueOf("59e1416a5000", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -98,7 +98,7 @@ public class CalculatorTest {
                         1))),
             Arrays.asList(
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -108,7 +108,7 @@ public class CalculatorTest {
                         "0x",
                         Script.HashType.DATA)),
                 new CellOutput(
-                    Numeric.toBigInt("0x59e1416a5000"),
+                    Long.valueOf("59e1416a5000", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -118,7 +118,7 @@ public class CalculatorTest {
                 Numeric.hexStringToByteArray(
                     "0x82df73581bcd08cb9aa270128d15e79996229ce8ea9e4f985b49fbf36762c5c37936caf3ea3784ee326f60b8992924fcf496f9503c907982525a3436f01ab32900")));
     Assertions.assertEquals(
-        Calculator.calculateTransactionFee(tx, BigInteger.valueOf(900)), BigInteger.valueOf(483));
+        Calculator.calculateTransactionFee(tx, 900), BigInteger.valueOf(483));
   }
 
   @Test
@@ -142,7 +142,7 @@ public class CalculatorTest {
                         1))),
             Collections.singletonList(
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -173,13 +173,13 @@ public class CalculatorTest {
                         1))),
             Arrays.asList(
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
                         Script.HashType.TYPE)),
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -215,7 +215,7 @@ public class CalculatorTest {
                         1))),
             Collections.singletonList(
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
@@ -251,13 +251,13 @@ public class CalculatorTest {
                         1))),
             Arrays.asList(
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",
                         Script.HashType.TYPE)),
                 new CellOutput(
-                    Numeric.toBigInt("0x174876e800"),
+                    Long.valueOf("174876e800", 16),
                     createScript(
                         "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
                         "0x59a27ef3ba84f061517d13f42cf44ed020610061",

--- a/core/src/test/java/utils/CovertTest.java
+++ b/core/src/test/java/utils/CovertTest.java
@@ -30,13 +30,13 @@ public class CovertTest {
     List<CellOutput> cellOutputs = new ArrayList<>();
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("100000000000"),
+            100000000000L,
             createScript(
                 "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08",
                 "0xe2193df51d78411601796b35b17b4f8f2cd85bd0")));
     cellOutputs.add(
         new CellOutput(
-            new BigInteger("4900000000000"),
+            4900000000000L,
             createScript(
                 "0xe3b513a2105a5d4f833d1fad3d968b96b4510687234cd909f86b3ac450d8a2b5",
                 "0x36c329ed630d6ce750712a477543672adab57f4c")));

--- a/example/src/main/java/org/nervos/ckb/ACPTransactionExample.java
+++ b/example/src/main/java/org/nervos/ckb/ACPTransactionExample.java
@@ -69,7 +69,7 @@ public class ACPTransactionExample {
   public static void main(String[] args) throws Exception {
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)) / (UnitCKB)
+            + Long.divideUnsigned(getBalance(SendAddresses.get(0)), UnitCKB)
             + " CKB");
 
     byte[] acpHash = createACPCell();
@@ -113,7 +113,7 @@ public class ACPTransactionExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (collectResult.changeCapacity >= MIN_CKB) {
+    if (Long.compareUnsigned(collectResult.changeCapacity, MIN_CKB) >= 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
 
@@ -185,7 +185,7 @@ public class ACPTransactionExample {
             SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2, sudtType);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (collectResult.changeCapacity >= MIN_SUDT_CKB) {
+      if (Long.compareUnsigned(collectResult.changeCapacity, MIN_SUDT_CKB) >= 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
     } else {

--- a/example/src/main/java/org/nervos/ckb/ACPTransactionExample.java
+++ b/example/src/main/java/org/nervos/ckb/ACPTransactionExample.java
@@ -69,7 +69,7 @@ public class ACPTransactionExample {
   public static void main(String[] args) throws Exception {
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)).divide(UnitCKB).toString(10)
+            + getBalance(SendAddresses.get(0)) / (UnitCKB)
             + " CKB");
 
     byte[] acpHash = createACPCell();
@@ -81,7 +81,7 @@ public class ACPTransactionExample {
         "Transfer acp tx hash: " + transfer(new OutPoint(acpHash, 0), BigInteger.valueOf(1000L)));
   }
 
-  private static BigInteger getBalance(String address) throws IOException {
+  private static long getBalance(String address) throws IOException {
     return new IndexerCollector(api, ckbIndexerApi).getCapacity(address);
   }
 
@@ -105,7 +105,7 @@ public class ACPTransactionExample {
     txBuilder.addCellDep(new CellDep(new OutPoint(SUDT_TX_HASH, 0), CellDep.DepType.CODE));
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     // collectInputsWithIndexer method uses indexer rpc to collect cells quickly
@@ -113,9 +113,8 @@ public class ACPTransactionExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(MIN_CKB) >= 0) {
-      cellOutputs.get(cellOutputs.size() - 1).capacity =
-          new BigInteger(collectResult.changeCapacity);
+    if (collectResult.changeCapacity >= MIN_CKB) {
+      cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
 
       outputsData.add(new byte[] {});
@@ -177,7 +176,7 @@ public class ACPTransactionExample {
     txBuilder.addCellDep(new CellDep(new OutPoint(SUDT_TX_HASH, 0), CellDep.DepType.CODE));
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1500);
+    long feeRate = 1500;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     // collectInputsWithIndexer method uses indexer rpc to collect cells quickly
@@ -186,9 +185,8 @@ public class ACPTransactionExample {
             SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2, sudtType);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(MIN_SUDT_CKB) >= 0) {
-      cellOutputs.get(cellOutputs.size() - 1).capacity =
-          new BigInteger(collectResult.changeCapacity);
+    if (collectResult.changeCapacity >= MIN_SUDT_CKB) {
+      cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
     } else {
       throw new IOException("The change capacity is not enough for the SUDT cell");

--- a/example/src/main/java/org/nervos/ckb/MultiKeySingleSigTxExample.java
+++ b/example/src/main/java/org/nervos/ckb/MultiKeySingleSigTxExample.java
@@ -124,8 +124,8 @@ public class MultiKeySingleSigTxExample {
   }
 
   private static long getBalance(String address) throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(address) / UnitCKB;
+    return Long.divideUnsigned(new IndexerCollector(api, ckbIndexerApi)
+        .getCapacity(address), UnitCKB);
   }
 
   private static byte[] sendCapacity(

--- a/example/src/main/java/org/nervos/ckb/MultiKeySingleSigTxExample.java
+++ b/example/src/main/java/org/nervos/ckb/MultiKeySingleSigTxExample.java
@@ -3,7 +3,6 @@ package org.nervos.ckb;
 import static org.nervos.ckb.utils.Const.*;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -124,11 +123,9 @@ public class MultiKeySingleSigTxExample {
         "After transferring, change address's balance: " + getBalance(changeAddress) + " CKB");
   }
 
-  private static String getBalance(String address) throws IOException {
+  private static long getBalance(String address) throws IOException {
     return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(address)
-        .divide(UnitCKB)
-        .toString(10);
+        .getCapacity(address) / UnitCKB;
   }
 
   private static byte[] sendCapacity(
@@ -160,14 +157,14 @@ public class MultiKeySingleSigTxExample {
     txBuilder.addOutputs(cellOutputs);
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     CollectResult collectResult =
         txUtils.collectInputs(sendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change output capacity after collecting cells
-    cellOutputs.get(cellOutputs.size() - 1).capacity = new BigInteger(collectResult.changeCapacity);
+    cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 
     int startIndex = 0;

--- a/example/src/main/java/org/nervos/ckb/MultiSignTransactionExample.java
+++ b/example/src/main/java/org/nervos/ckb/MultiSignTransactionExample.java
@@ -4,7 +4,6 @@ import static org.nervos.ckb.utils.Const.*;
 
 import com.google.common.primitives.Bytes;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -90,19 +89,17 @@ public class MultiSignTransactionExample {
             + " CKB");
   }
 
-  public static String getMultiSigBalance() throws IOException {
+  public static long getMultiSigBalance() throws IOException {
     return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(configuration.address())
-        .divide(UnitCKB)
-        .toString();
+        .getCapacity(configuration.address()) / UnitCKB;
   }
 
-  public static String getBalance(String address) throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi).getCapacity(address).divide(UnitCKB).toString();
+  public static long getBalance(String address) throws IOException {
+    return new IndexerCollector(api, ckbIndexerApi).getCapacity(address) / UnitCKB;
   }
 
   public static Transaction generateTx(
-      String targetAddress, BigInteger capacity, List<String> privateKeys) throws IOException {
+      String targetAddress, long capacity, List<String> privateKeys) throws IOException {
     if (privateKeys.size() != configuration.threshold) {
       throw new IOException("Invalid number of keys");
     }
@@ -117,7 +114,7 @@ public class MultiSignTransactionExample {
     txBuilder.addOutputs(cellOutputs);
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = multi_sig_hash.length + 2 * secp256k1_signature_byte.length
     CollectResult collectResult =
@@ -128,7 +125,7 @@ public class MultiSignTransactionExample {
             configuration.serialize().length() + configuration.threshold * Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells
-    cellOutputs.get(cellOutputs.size() - 1).capacity = new BigInteger(collectResult.changeCapacity);
+    cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 
     int startIndex = 0;
@@ -157,7 +154,7 @@ public class MultiSignTransactionExample {
   }
 
   public static byte[] sendCapacity(
-      String targetAddress, BigInteger capacity, List<String> privateKeys) throws IOException {
+      String targetAddress, long capacity, List<String> privateKeys) throws IOException {
     Transaction tx = generateTx(targetAddress, capacity, privateKeys);
     return api.sendTransaction(tx);
   }

--- a/example/src/main/java/org/nervos/ckb/MultiSignTransactionExample.java
+++ b/example/src/main/java/org/nervos/ckb/MultiSignTransactionExample.java
@@ -90,12 +90,12 @@ public class MultiSignTransactionExample {
   }
 
   public static long getMultiSigBalance() throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(configuration.address()) / UnitCKB;
+    return Long.divideUnsigned(new IndexerCollector(api, ckbIndexerApi)
+        .getCapacity(configuration.address()), UnitCKB);
   }
 
   public static long getBalance(String address) throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi).getCapacity(address) / UnitCKB;
+    return Long.divideUnsigned(new IndexerCollector(api, ckbIndexerApi).getCapacity(address), UnitCKB);
   }
 
   public static Transaction generateTx(

--- a/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
+++ b/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
@@ -83,14 +83,12 @@ public class NervosDaoExample {
     }
   }
 
-  private static String getBalance(String address) throws IOException {
+  private static long getBalance(String address) throws IOException {
     return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(address)
-        .divide(UnitCKB)
-        .toString(10);
+        .getCapacity(address) / UnitCKB;
   }
 
-  private static Transaction generateDepositingToDaoTx(BigInteger capacity) throws IOException {
+  private static Transaction generateDepositingToDaoTx(long capacity) throws IOException {
     Script type =
         new Script(
             SystemContract.getSystemNervosDaoCell(api).cellHash,
@@ -114,7 +112,7 @@ public class NervosDaoExample {
         new CellDep(SystemContract.getSystemNervosDaoCell(api).outPoint, CellDep.DepType.CODE));
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
     IndexerCollector indexerCollector = new IndexerCollector(api, ckbIndexerApi);
     CollectResult collectResult =
         indexerCollector.collectInputs(
@@ -124,7 +122,7 @@ public class NervosDaoExample {
             Sign.SIGN_LENGTH * 2);
 
     // update change output capacity after collecting cells
-    cellOutputs.get(cellOutputs.size() - 1).capacity = new BigInteger(collectResult.changeCapacity);
+    cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 
     int startIndex = 0;
@@ -166,7 +164,7 @@ public class NervosDaoExample {
     byte[] outputData = new UInt64(depositBlockNumber).toBytes();
 
     Script lock = LockUtils.generateLockScriptWithAddress(DaoTestAddress);
-    CellOutput changeOutput = new CellOutput(BigInteger.ZERO, lock);
+    CellOutput changeOutput = new CellOutput(0, lock);
 
     List<CellOutput> cellOutputs = Arrays.asList(cellOutput, changeOutput);
     List<byte[]> cellOutputsData = Arrays.asList(outputData, new byte[] {});
@@ -182,7 +180,7 @@ public class NervosDaoExample {
     txBuilder.addInput(new CellInput(depositOutPoint));
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
     IndexerCollector indexerCollector = new IndexerCollector(api, ckbIndexerApi);
     CollectResult collectResult =
         indexerCollector.collectInputs(
@@ -192,7 +190,7 @@ public class NervosDaoExample {
             Sign.SIGN_LENGTH * 2);
 
     // update change output capacity after collecting cells
-    cellOutputs.get(cellOutputs.size() - 1).capacity = new BigInteger(collectResult.changeCapacity);
+    cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 
     CellsWithAddress cellsWithAddress = collectResult.cellsWithAddresses.get(0);
@@ -219,7 +217,7 @@ public class NervosDaoExample {
   }
 
   private static Transaction generateClaimingFromDaoTx(
-      OutPoint depositOutPoint, OutPoint withdrawingOutPoint, BigInteger fee) throws IOException {
+      OutPoint depositOutPoint, OutPoint withdrawingOutPoint, long fee) throws IOException {
     Script lock = LockUtils.generateLockScriptWithAddress(DaoTestAddress);
     CellWithStatus cellWithStatus = api.getLiveCell(withdrawingOutPoint, true);
     if (!(CellWithStatus.Status.LIVE == cellWithStatus.status)) {
@@ -257,11 +255,11 @@ public class NervosDaoExample {
     //            EpochUtils.generateSince(
     //                minimalSinceEpochLength, minimalSinceEpochIndex, minimalSinceEpochNumber));
     long minimalSince = 0;
-    BigInteger outputCapacity =
+    long outputCapacity =
         api.calculateDaoMaximumWithdraw(
             depositOutPoint, Numeric.toHexString(withdrawBlock.header.hash));
 
-    CellOutput cellOutput = new CellOutput(outputCapacity.subtract(fee), lock);
+    CellOutput cellOutput = new CellOutput(outputCapacity - fee, lock);
 
     SystemScriptCell secpCell = SystemContract.getSystemSecpCell(api);
     SystemScriptCell nervosDaoCell = SystemContract.getSystemNervosDaoCell(api);

--- a/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
+++ b/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
@@ -232,10 +232,10 @@ public class NervosDaoExample {
 
     int depositBlockNumber = new UInt64(cellWithStatus.cell.data.content).getValue().intValue();
     Block depositBlock = api.getBlockByNumber(depositBlockNumber);
-    EpochUtils.EpochInfo depositEpoch = EpochUtils.parse(depositBlock.header.epoch.toByteArray());
+    EpochUtils.EpochInfo depositEpoch = EpochUtils.parse(depositBlock.header.epoch);
 
     Block withdrawBlock = api.getBlock(transactionWithStatus.txStatus.blockHash);
-    EpochUtils.EpochInfo withdrawEpoch = EpochUtils.parse(withdrawBlock.header.epoch.toByteArray());
+    EpochUtils.EpochInfo withdrawEpoch = EpochUtils.parse(withdrawBlock.header.epoch);
 
     long withdrawFraction = withdrawEpoch.index * depositEpoch.length;
     long depositFraction = depositEpoch.index * withdrawEpoch.length;
@@ -256,7 +256,7 @@ public class NervosDaoExample {
     //        Numeric.hexStringToByteArray(
     //            EpochUtils.generateSince(
     //                minimalSinceEpochLength, minimalSinceEpochIndex, minimalSinceEpochNumber));
-    BigInteger minimalSince = BigInteger.ZERO;
+    long minimalSince = 0;
     BigInteger outputCapacity =
         api.calculateDaoMaximumWithdraw(
             depositOutPoint, Numeric.toHexString(withdrawBlock.header.hash));

--- a/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
+++ b/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
@@ -257,7 +257,7 @@ public class NervosDaoExample {
     long minimalSince = 0;
     long outputCapacity =
         api.calculateDaoMaximumWithdraw(
-            depositOutPoint, Numeric.toHexString(withdrawBlock.header.hash));
+            depositOutPoint, withdrawBlock.header.hash);
 
     CellOutput cellOutput = new CellOutput(outputCapacity - fee, lock);
 

--- a/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
+++ b/example/src/main/java/org/nervos/ckb/NervosDaoExample.java
@@ -84,8 +84,8 @@ public class NervosDaoExample {
   }
 
   private static long getBalance(String address) throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(address) / UnitCKB;
+    return Long.divideUnsigned(new IndexerCollector(api, ckbIndexerApi)
+        .getCapacity(address), UnitCKB);
   }
 
   private static Transaction generateDepositingToDaoTx(long capacity) throws IOException {

--- a/example/src/main/java/org/nervos/ckb/RpcExample.java
+++ b/example/src/main/java/org/nervos/ckb/RpcExample.java
@@ -4,7 +4,6 @@ import static org.nervos.ckb.utils.Const.*;
 
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.math.BigInteger;
 import org.nervos.ckb.service.Api;
 import org.nervos.ckb.type.Block;
 import org.nervos.ckb.type.BlockchainInfo;
@@ -23,18 +22,18 @@ public class RpcExample {
     RpcExample client = new RpcExample();
     System.out.println(
         "CKB Blockchain information: " + new Gson().toJson(client.getBlockchainInfo()));
-    BigInteger currentBlockNumber = client.getTipBlockNumber();
-    System.out.println("Current block number: " + currentBlockNumber.toString());
+    long currentBlockNumber = client.getTipBlockNumber();
+    System.out.println("Current block number: " + currentBlockNumber);
     System.out.println(
         "Current block information: "
-            + new Gson().toJson(client.getBlockByNumber(currentBlockNumber.intValue())));
+            + new Gson().toJson(client.getBlockByNumber(currentBlockNumber)));
   }
 
-  public Block getBlockByNumber(int blockNumber) throws IOException {
+  public Block getBlockByNumber(long blockNumber) throws IOException {
     return api.getBlockByNumber(blockNumber);
   }
 
-  public BigInteger getTipBlockNumber() throws IOException {
+  public long getTipBlockNumber() throws IOException {
     return api.getTipBlockNumber();
   }
 

--- a/example/src/main/java/org/nervos/ckb/SUDTExample.java
+++ b/example/src/main/java/org/nervos/ckb/SUDTExample.java
@@ -3,7 +3,6 @@ package org.nervos.ckb;
 import static org.nervos.ckb.utils.Const.*;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,7 +18,6 @@ import org.nervos.ckb.type.cell.CellDep;
 import org.nervos.ckb.type.cell.CellOutput;
 import org.nervos.ckb.type.fixed.UInt128;
 import org.nervos.ckb.type.transaction.Transaction;
-import org.nervos.ckb.utils.Numeric;
 import org.nervos.ckb.utils.Utils;
 import org.nervos.ckb.utils.address.AddressParser;
 
@@ -27,8 +25,8 @@ import org.nervos.ckb.utils.address.AddressParser;
 // SUDT RFC:
 // https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0025-simple-udt/0025-simple-udt.md
 public class SUDTExample {
-  private static final BigInteger SUDT_ISSUE_SUM_AMOUNT = new BigInteger("1000000000000");
-  private static final BigInteger SUDT_TRANSFER_AMOUNT = new BigInteger("60000000000");
+  private static final long SUDT_ISSUE_SUM_AMOUNT = 1000000000000L;
+  private static final long SUDT_TRANSFER_AMOUNT = 60000000000L;
 
   private static Api api;
   private static CkbIndexerApi ckbIndexerApi;
@@ -54,7 +52,7 @@ public class SUDTExample {
   public static void main(String[] args) throws Exception {
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)).divide(UnitCKB).toString(10)
+            + getBalance(SendAddresses.get(0)) / UnitCKB
             + " CKB");
 
     System.out.println("Issue SUDT tx hash: " + issue());
@@ -65,7 +63,7 @@ public class SUDTExample {
     System.out.println("Transfer SUDT tx hash: " + transfer());
   }
 
-  private static BigInteger getBalance(String address) throws IOException {
+  private static long getBalance(String address) throws IOException {
     return new IndexerCollector(api, ckbIndexerApi).getCapacity(address);
   }
 
@@ -86,7 +84,7 @@ public class SUDTExample {
     txBuilder.addCellDep(new CellDep(new OutPoint(SUDT_TX_HASH, 0), CellDep.DepType.CODE));
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     // collectInputsWithIndexer method uses indexer rpc to collect cells quickly
@@ -94,9 +92,9 @@ public class SUDTExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(MIN_CKB) >= 0) {
+    if (collectResult.changeCapacity >= MIN_CKB) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
-          new BigInteger(collectResult.changeCapacity);
+          collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
     }
 
@@ -142,7 +140,7 @@ public class SUDTExample {
     txBuilder.addCellDep(new CellDep(new OutPoint(SUDT_TX_HASH, 0), CellDep.DepType.CODE));
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1500);
+    long feeRate = 1500;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     // collectInputsWithIndexer method uses indexer rpc to collect cells quickly
@@ -151,9 +149,9 @@ public class SUDTExample {
             SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2, sudtType);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(MIN_CKB) >= 0) {
+    if (collectResult.changeCapacity >= MIN_CKB) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
-          new BigInteger(collectResult.changeCapacity);
+          collectResult.changeCapacity;
       cellOutputs.get(cellOutputs.size() - 1).type = sudtType;
       txBuilder.setOutputs(cellOutputs);
     }
@@ -161,7 +159,7 @@ public class SUDTExample {
     txBuilder.setOutputsData(
         Arrays.asList(
             new UInt128((SUDT_TRANSFER_AMOUNT)).toBytes(),
-            new UInt128(SUDT_ISSUE_SUM_AMOUNT.subtract(SUDT_TRANSFER_AMOUNT)).toBytes()));
+            new UInt128(SUDT_ISSUE_SUM_AMOUNT - SUDT_TRANSFER_AMOUNT).toBytes()));
 
     int startIndex = 0;
     for (CellsWithAddress cellsWithAddress : collectResult.cellsWithAddresses) {

--- a/example/src/main/java/org/nervos/ckb/SUDTExample.java
+++ b/example/src/main/java/org/nervos/ckb/SUDTExample.java
@@ -52,7 +52,7 @@ public class SUDTExample {
   public static void main(String[] args) throws Exception {
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)) / UnitCKB
+            + Long.divideUnsigned(getBalance(SendAddresses.get(0)), UnitCKB)
             + " CKB");
 
     System.out.println("Issue SUDT tx hash: " + issue());
@@ -92,7 +92,7 @@ public class SUDTExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (collectResult.changeCapacity >= MIN_CKB) {
+    if (Long.compareUnsigned(collectResult.changeCapacity, MIN_CKB) >= 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
           collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
@@ -149,7 +149,7 @@ public class SUDTExample {
             SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2, sudtType);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (collectResult.changeCapacity >= MIN_CKB) {
+    if (Long.compareUnsigned(collectResult.changeCapacity, MIN_CKB) >= 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
           collectResult.changeCapacity;
       cellOutputs.get(cellOutputs.size() - 1).type = sudtType;

--- a/example/src/main/java/org/nervos/ckb/SendToMultiSigAddressTxExample.java
+++ b/example/src/main/java/org/nervos/ckb/SendToMultiSigAddressTxExample.java
@@ -3,7 +3,6 @@ package org.nervos.ckb;
 import static org.nervos.ckb.utils.Const.*;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -58,18 +57,14 @@ public class SendToMultiSigAddressTxExample {
     System.out.println("After transferring, change address balance: " + getBalance() + " CKB");
   }
 
-  private static String getBalance() throws IOException {
+  private static long getBalance() throws IOException {
     return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(TestAddress)
-        .divide(UnitCKB)
-        .toString(10);
+        .getCapacity(TestAddress) / UnitCKB;
   }
 
-  private static String getMultiSigBalance() throws IOException {
+  private static long getMultiSigBalance() throws IOException {
     return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(MultiSigAddress)
-        .divide(UnitCKB)
-        .toString(10);
+        .getCapacity(MultiSigAddress) / UnitCKB;
   }
 
   private static byte[] sendCapacity(List<Receiver> receivers, String changeAddress)
@@ -83,7 +78,7 @@ public class SendToMultiSigAddressTxExample {
     List<ScriptGroupWithPrivateKeys> scriptGroupWithPrivateKeysList = new ArrayList<>();
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     CollectResult collectResult =
@@ -94,7 +89,7 @@ public class SendToMultiSigAddressTxExample {
             Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells
-    cellOutputs.get(cellOutputs.size() - 1).capacity = new BigInteger(collectResult.changeCapacity);
+    cellOutputs.get(cellOutputs.size() - 1).capacity = collectResult.changeCapacity;
     txBuilder.setOutputs(cellOutputs);
 
     int startIndex = 0;

--- a/example/src/main/java/org/nervos/ckb/SendToMultiSigAddressTxExample.java
+++ b/example/src/main/java/org/nervos/ckb/SendToMultiSigAddressTxExample.java
@@ -58,13 +58,13 @@ public class SendToMultiSigAddressTxExample {
   }
 
   private static long getBalance() throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(TestAddress) / UnitCKB;
+    return Long.divideUnsigned(new IndexerCollector(api, ckbIndexerApi)
+        .getCapacity(TestAddress), UnitCKB);
   }
 
   private static long getMultiSigBalance() throws IOException {
-    return new IndexerCollector(api, ckbIndexerApi)
-        .getCapacity(MultiSigAddress) / UnitCKB;
+    return Long.divideUnsigned(new IndexerCollector(api, ckbIndexerApi)
+        .getCapacity(MultiSigAddress), UnitCKB);
   }
 
   private static byte[] sendCapacity(List<Receiver> receivers, String changeAddress)

--- a/example/src/main/java/org/nervos/ckb/SingleSigWithCkbIndexerTxExample.java
+++ b/example/src/main/java/org/nervos/ckb/SingleSigWithCkbIndexerTxExample.java
@@ -62,7 +62,7 @@ public class SingleSigWithCkbIndexerTxExample {
 
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)) / UnitCKB
+            + Long.divideUnsigned(getBalance(SendAddresses.get(0)), UnitCKB)
             + " CKB");
 
     byte[] hash = sendCapacity(receivers, SendAddresses.get(0));
@@ -73,7 +73,7 @@ public class SingleSigWithCkbIndexerTxExample {
 
     System.out.println(
         "After transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)) / UnitCKB
+            + Long.divideUnsigned(getBalance(SendAddresses.get(0)), UnitCKB)
             + " CKB");
   }
 
@@ -100,7 +100,7 @@ public class SingleSigWithCkbIndexerTxExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (collectResult.changeCapacity > 0) {
+      if (Long.compareUnsigned(collectResult.changeCapacity, 0) > 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
           collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);

--- a/example/src/main/java/org/nervos/ckb/SingleSigWithCkbIndexerTxExample.java
+++ b/example/src/main/java/org/nervos/ckb/SingleSigWithCkbIndexerTxExample.java
@@ -3,7 +3,6 @@ package org.nervos.ckb;
 import static org.nervos.ckb.utils.Const.*;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,7 +17,6 @@ import org.nervos.ckb.transaction.*;
 import org.nervos.ckb.type.Witness;
 import org.nervos.ckb.type.cell.CellOutput;
 import org.nervos.ckb.type.transaction.Transaction;
-import org.nervos.ckb.utils.Numeric;
 import org.nervos.ckb.utils.Utils;
 
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
@@ -64,7 +62,7 @@ public class SingleSigWithCkbIndexerTxExample {
 
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)).divide(UnitCKB).toString(10)
+            + getBalance(SendAddresses.get(0)) / UnitCKB
             + " CKB");
 
     byte[] hash = sendCapacity(receivers, SendAddresses.get(0));
@@ -75,11 +73,11 @@ public class SingleSigWithCkbIndexerTxExample {
 
     System.out.println(
         "After transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)).divide(UnitCKB).toString(10)
+            + getBalance(SendAddresses.get(0)) / UnitCKB
             + " CKB");
   }
 
-  private static BigInteger getBalance(String address) throws IOException {
+  private static long getBalance(String address) throws IOException {
     return new IndexerCollector(api, ckbIndexerApi).getCapacity(address);
   }
 
@@ -94,7 +92,7 @@ public class SingleSigWithCkbIndexerTxExample {
     txBuilder.addOutputs(cellOutputs);
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     // collectInputsWithIndexer method uses indexer rpc to collect cells quickly
@@ -102,9 +100,9 @@ public class SingleSigWithCkbIndexerTxExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(BigInteger.ZERO) > 0) {
+    if (collectResult.changeCapacity > 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
-          new BigInteger(collectResult.changeCapacity);
+          collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
     }
 

--- a/example/src/main/java/org/nervos/ckb/TransferAllBalanceWithCkbIndexerExample.java
+++ b/example/src/main/java/org/nervos/ckb/TransferAllBalanceWithCkbIndexerExample.java
@@ -3,7 +3,6 @@ package org.nervos.ckb;
 import static org.nervos.ckb.utils.Const.*;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +16,6 @@ import org.nervos.ckb.transaction.*;
 import org.nervos.ckb.type.Witness;
 import org.nervos.ckb.type.cell.CellOutput;
 import org.nervos.ckb.type.transaction.Transaction;
-import org.nervos.ckb.utils.Numeric;
 import org.nervos.ckb.utils.Utils;
 
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
@@ -61,7 +59,7 @@ public class TransferAllBalanceWithCkbIndexerExample {
 
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)).divide(UnitCKB).toString(10)
+            + getBalance(SendAddresses.get(0)) / UnitCKB
             + " CKB");
 
     // For transferring all balance, change address is set to be null
@@ -75,11 +73,11 @@ public class TransferAllBalanceWithCkbIndexerExample {
 
     System.out.println(
         "After transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)).divide(UnitCKB).toString(10)
+            + getBalance(SendAddresses.get(0)) / UnitCKB
             + " CKB");
   }
 
-  private static BigInteger getBalance(String address) throws IOException {
+  private static long getBalance(String address) throws IOException {
     return new IndexerCollector(api, ckbIndexerApi).getCapacity(address);
   }
 
@@ -94,7 +92,7 @@ public class TransferAllBalanceWithCkbIndexerExample {
     txBuilder.addOutputs(cellOutputs);
 
     // You can get fee rate by rpc or set a simple number
-    BigInteger feeRate = BigInteger.valueOf(1024);
+    long feeRate = 1024;
 
     // initial_length = 2 * secp256k1_signature_byte.length
     // collectInputsWithIndexer method uses indexer rpc to collect cells quickly
@@ -102,9 +100,9 @@ public class TransferAllBalanceWithCkbIndexerExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (Numeric.toBigInt(collectResult.changeCapacity).compareTo(BigInteger.ZERO) > 0) {
+    if (collectResult.changeCapacity > 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
-          new BigInteger(collectResult.changeCapacity);
+          collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);
     }
 

--- a/example/src/main/java/org/nervos/ckb/TransferAllBalanceWithCkbIndexerExample.java
+++ b/example/src/main/java/org/nervos/ckb/TransferAllBalanceWithCkbIndexerExample.java
@@ -59,7 +59,7 @@ public class TransferAllBalanceWithCkbIndexerExample {
 
     System.out.println(
         "Before transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)) / UnitCKB
+            + Long.divideUnsigned(getBalance(SendAddresses.get(0)), UnitCKB)
             + " CKB");
 
     // For transferring all balance, change address is set to be null
@@ -73,7 +73,7 @@ public class TransferAllBalanceWithCkbIndexerExample {
 
     System.out.println(
         "After transferring, first sender's balance: "
-            + getBalance(SendAddresses.get(0)) / UnitCKB
+            + Long.divideUnsigned(getBalance(SendAddresses.get(0)), UnitCKB)
             + " CKB");
   }
 
@@ -100,7 +100,7 @@ public class TransferAllBalanceWithCkbIndexerExample {
         txUtils.collectInputs(SendAddresses, txBuilder.buildTx(), feeRate, Sign.SIGN_LENGTH * 2);
 
     // update change cell output capacity after collecting cells if there is changeOutput
-    if (collectResult.changeCapacity > 0) {
+    if (Long.compareUnsigned(collectResult.changeCapacity, 0) > 0) {
       cellOutputs.get(cellOutputs.size() - 1).capacity =
           collectResult.changeCapacity;
       txBuilder.setOutputs(cellOutputs);

--- a/example/src/main/java/org/nervos/ckb/indexer/CellCkbIndexerIterator.java
+++ b/example/src/main/java/org/nervos/ckb/indexer/CellCkbIndexerIterator.java
@@ -113,7 +113,7 @@ public class CellCkbIndexerIterator implements Iterator<TransactionInput> {
         continue;
       }
       CellInput cellInput = new CellInput(liveCell.outPoint);
-      BigInteger capacity = liveCell.output.capacity;
+      long capacity = liveCell.output.capacity;
       transactionInputs.add(
           new TransactionInput(
               cellInput, capacity, Numeric.toHexString(searchKey.script.computeHash())));
@@ -146,7 +146,7 @@ public class CellCkbIndexerIterator implements Iterator<TransactionInput> {
         continue;
       }
       CellInput cellInput = new CellInput(liveCell.outPoint);
-      BigInteger capacity = liveCell.output.capacity;
+      long capacity = liveCell.output.capacity;
       transactionInputs.add(new TransactionInput(cellInput, capacity, lockHash));
     }
     if (liveCells.size() == 0) {

--- a/example/src/main/java/org/nervos/ckb/indexer/CkbIndexerCellsCapacity.java
+++ b/example/src/main/java/org/nervos/ckb/indexer/CkbIndexerCellsCapacity.java
@@ -10,5 +10,5 @@ public class CkbIndexerCellsCapacity {
   @SerializedName("block_number")
   public int blockNumber;
 
-  public BigInteger capacity;
+  public long capacity;
 }

--- a/example/src/main/java/org/nervos/ckb/indexer/IndexerCollector.java
+++ b/example/src/main/java/org/nervos/ckb/indexer/IndexerCollector.java
@@ -25,7 +25,7 @@ public class IndexerCollector {
   }
 
   public CollectResult collectInputs(
-      List<String> addresses, Transaction transaction, BigInteger feeRate, int initialLength)
+      List<String> addresses, Transaction transaction, long feeRate, int initialLength)
       throws IOException {
     return new CellCollector(api)
         .collectInputs(
@@ -39,7 +39,7 @@ public class IndexerCollector {
   public CollectResult collectInputs(
       List<String> addresses,
       Transaction transaction,
-      BigInteger feeRate,
+      long feeRate,
       int initialLength,
       Script type)
       throws IOException {
@@ -52,7 +52,7 @@ public class IndexerCollector {
             new CellCkbIndexerIterator(indexerApi, addresses, type));
   }
 
-  public BigInteger getCapacity(String address) throws IOException {
+  public long getCapacity(String address) throws IOException {
     AddressParseResult rs = AddressParser.parse(address);
     CkbIndexerCellsCapacity capacityInfo = indexerApi.getCellsCapacity(new SearchKey(rs.script));
 
@@ -69,7 +69,7 @@ public class IndexerCollector {
     // so change output is not needed
     if (changeAddress != null && !changeAddress.trim().isEmpty()) {
       AddressParseResult addressParseResult = AddressParser.parse(changeAddress);
-      cellOutputs.add(new CellOutput(BigInteger.ZERO, addressParseResult.script));
+      cellOutputs.add(new CellOutput(0, addressParseResult.script));
     }
 
     return cellOutputs;

--- a/example/src/main/java/org/nervos/ckb/indexer/Receiver.java
+++ b/example/src/main/java/org/nervos/ckb/indexer/Receiver.java
@@ -5,9 +5,9 @@ import java.math.BigInteger;
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class Receiver {
   public String address;
-  public BigInteger capacity;
+  public long capacity;
 
-  public Receiver(String address, BigInteger capacity) {
+  public Receiver(String address, long capacity) {
     this.address = address;
     this.capacity = capacity;
   }

--- a/example/src/main/java/org/nervos/ckb/utils/Const.java
+++ b/example/src/main/java/org/nervos/ckb/utils/Const.java
@@ -7,9 +7,9 @@ public class Const {
   public static final String NODE_URL = "http://localhost:8114";
   public static final String CKB_INDEXER_URL = "http://localhost:8116";
 
-  public static final BigInteger UnitCKB = new BigInteger("100000000");
-  public static final BigInteger MIN_CKB = new BigInteger("6100000000");
-  public static final BigInteger MIN_SUDT_CKB = new BigInteger("14200000000");
+  public static final long UnitCKB = 100000000L;
+  public static final long MIN_CKB = 6100000000L;
+  public static final long MIN_SUDT_CKB = 14200000000L;
 
   public static final byte[] SUDT_CODE_HASH =
       Numeric.hexStringToByteArray(

--- a/example/src/test/java/org/nervos/ckb/CkbIndexerApiTest.java
+++ b/example/src/test/java/org/nervos/ckb/CkbIndexerApiTest.java
@@ -1,7 +1,6 @@
 package org.nervos.ckb;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.nervos.ckb.indexer.*;
@@ -29,7 +28,7 @@ public class CkbIndexerApiTest {
   public void testGetCellCapacity() throws IOException {
     SearchKey searchKey = newSearchKey();
     CkbIndexerCellsCapacity cellsCapacity = service.getCellsCapacity(searchKey);
-    Assertions.assertTrue(cellsCapacity.capacity.compareTo(BigInteger.ZERO) > 0);
+    Assertions.assertTrue(cellsCapacity.capacity > 0);
   }
 
   private SearchKey newSearchKey() {

--- a/example/src/test/java/org/nervos/ckb/CkbIndexerApiTest.java
+++ b/example/src/test/java/org/nervos/ckb/CkbIndexerApiTest.java
@@ -28,7 +28,7 @@ public class CkbIndexerApiTest {
   public void testGetCellCapacity() throws IOException {
     SearchKey searchKey = newSearchKey();
     CkbIndexerCellsCapacity cellsCapacity = service.getCellsCapacity(searchKey);
-    Assertions.assertTrue(cellsCapacity.capacity > 0);
+    Assertions.assertTrue(Long.compareUnsigned(cellsCapacity.capacity, 0) > 0);
   }
 
   private SearchKey newSearchKey() {

--- a/utils/src/main/java/org/nervos/ckb/utils/Utils.java
+++ b/utils/src/main/java/org/nervos/ckb/utils/Utils.java
@@ -5,15 +5,11 @@ import java.math.BigInteger;
 /** Copyright © 2019 Nervos Foundation. All rights reserved. */
 public class Utils {
 
-  public static BigInteger ckbToShannon(BigInteger value) {
-    return value.multiply(BigInteger.TEN.pow(8));
+  public static long ckbToShannon(long value) {
+    return (long) (value * Math.pow(10, 8));
   }
 
-  public static BigInteger ckbToShannon(long value) {
-    return BigInteger.valueOf(value).multiply(BigInteger.TEN.pow(8));
-  }
-
-  public static BigInteger ckbToShannon(double value) {
-    return BigInteger.valueOf((long) (value * Math.pow(10, 8)));
+  public static long ckbToShannon(double value) {
+    return (long) (value * Math.pow(10, 8));
   }
 }

--- a/utils/src/test/java/org/nervos/ckb/utils/UtilsTest.java
+++ b/utils/src/test/java/org/nervos/ckb/utils/UtilsTest.java
@@ -1,6 +1,5 @@
 package org.nervos.ckb.utils;
 
-import java.math.BigInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,11 +8,11 @@ public class UtilsTest {
 
   @Test
   public void testCkbToShannon() {
-    Assertions.assertEquals(BigInteger.valueOf(234300000000L), Utils.ckbToShannon(2343));
+    Assertions.assertEquals(234300000000L, Utils.ckbToShannon(2343));
   }
 
   @Test
   public void testCkbToShannonWithDouble() {
-    Assertions.assertEquals(new BigInteger("2560000"), Utils.ckbToShannon(0.0256));
+    Assertions.assertEquals(2560000, Utils.ckbToShannon(0.0256));
   }
 }

--- a/utils/src/test/java/org/nervos/ckb/utils/UtilsTest.java
+++ b/utils/src/test/java/org/nervos/ckb/utils/UtilsTest.java
@@ -13,13 +13,6 @@ public class UtilsTest {
   }
 
   @Test
-  public void testCkbToShannonWithBigInteger() {
-    Assertions.assertEquals(
-        new BigInteger("26589358000000000000"),
-        Utils.ckbToShannon(BigInteger.valueOf(265893580000L)));
-  }
-
-  @Test
   public void testCkbToShannonWithDouble() {
     Assertions.assertEquals(new BigInteger("2560000"), Utils.ckbToShannon(0.0256));
   }


### PR DESCRIPTION
This PR is mainly on type refactor, to refactor all fields of Uint32/Unit64 in [blockchain.mol](https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/blockchain.mol) and [CKB RPC doc](https://github.com/nervosnetwork/ckb/tree/develop/rpc) into int/long in Java SDK.

Some details on code implementations
- To focus on type refactor, I didn't check business logic carefully (most in ckb indexer and some utils methods) and only change code where the refactored field is used. This work to check business logic should be put into other PR.
- Also, types used only by mercury will be refactor in the future, not covered in this PR.
- ~~I didn't use unsigned method to manipulate capacity as they won't exceed LONG.MAX_VALUE in real cases and can work correctly with signed operations.~~