### PR TITLE
Chore: fix auto cd problems

### DIFF
--- a/ckb-indexer/build.gradle
+++ b/ckb-indexer/build.gradle
@@ -2,11 +2,12 @@ description 'SDK for CKB indexer'
 
 dependencies {
     compile project(":core")
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.9.0")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 
     // Enable use of the JUnitPlatform Runner within the IDE
-    testCompile("org.junit.platform:junit-platform-runner:1.9.0")
+    testImplementation("org.junit.platform:junit-platform-runner:1.9.0")
 }
 
 test {

--- a/ckb-indexer/src/test/java/indexer/TipTest.java
+++ b/ckb-indexer/src/test/java/indexer/TipTest.java
@@ -26,6 +26,9 @@ public class TipTest {
     Assertions.assertTrue(tip.blockNumber <= tip2.blockNumber);
   }
 
+  // both testnet and mainnet indexer url point to the ckb module ones, so no get_tip exist, it's get_indexer_tip,
+  // so if you use a old standalone ckb-indexer, should Configuration.setIndexerUrl yourself.
+  @Disabled
   @Test
   void getTipStandAlone() throws IOException {
     Configuration.getInstance().setIndexType(IndexerType.StandAlone);

--- a/ckb-mercury-sdk/build.gradle
+++ b/ckb-mercury-sdk/build.gradle
@@ -3,11 +3,11 @@ description 'SDK for CKB mercury'
 dependencies {
     compile project(":core")
     compile project(":ckb-indexer")
-    testCompile project(":ckb")
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.9.0")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+    testImplementation project(":ckb")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
     // Enable use of the JUnitPlatform Runner within the IDE
-    testCompile("org.junit.platform:junit-platform-runner:1.9.0")
+    testImplementation("org.junit.platform:junit-platform-runner:1.9.0")
 }
 
 test {

--- a/light-client/build.gradle
+++ b/light-client/build.gradle
@@ -11,8 +11,8 @@ repositories {
 
 dependencies {
     implementation project(":ckb-indexer")
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }
 
 test {


### PR DESCRIPTION
### What does this PR do?
1. chore: Update deprecated gradle functions to new ones;
2. test: Disable unittest getTipStandAlone since test indexer point to ckb module