### PR TITLE
feat: force small change as fee

### DIFF
--- a/ckb/src/main/java/org/nervos/ckb/transaction/AbstractTransactionBuilder.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/AbstractTransactionBuilder.java
@@ -8,7 +8,6 @@ import org.nervos.ckb.utils.Calculator;
 import java.util.*;
 
 public abstract class AbstractTransactionBuilder {
-  protected int changeOutputIndex = -1;
   protected TransactionBuilderConfiguration configuration;
   protected Iterator<TransactionInput> availableInputs;
   protected List<TransactionInput> inputsDetail = new ArrayList<>();

--- a/ckb/src/main/java/org/nervos/ckb/transaction/CkbTransactionBuilder.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/CkbTransactionBuilder.java
@@ -8,11 +8,17 @@ import org.nervos.ckb.type.*;
 import org.nervos.ckb.utils.Numeric;
 import org.nervos.ckb.utils.address.Address;
 
+import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CkbTransactionBuilder extends AbstractTransactionBuilder {
   protected List<TransactionInput> transactionInputs = new ArrayList<>();
   protected long reward = 0;
+  protected CellOutput changeOutput;
+  protected byte[] changeOutputData;
+  int transactionInputsIndex = 0;
 
   public CkbTransactionBuilder(TransactionBuilderConfiguration configuration, Iterator<TransactionInput> availableInputs) {
     super(configuration, availableInputs);
@@ -66,33 +72,66 @@ public class CkbTransactionBuilder extends AbstractTransactionBuilder {
   }
 
   /**
-   * Set change output. Its capacity will be overwritten later when building the transaction.
+   * Set possible change output. Its capacity must be 0.
    * <p>
    * Change output should be set only once.
    */
-  public CkbTransactionBuilder setChangeOutput(CellOutput output, byte[] data) {
-    if (changeOutputIndex != -1) {
+  public CkbTransactionBuilder setChangeOutput(@Nonnull CellOutput output, @Nonnull byte[] data) {
+    if (changeOutput != null) {
       throw new IllegalStateException("Change output has been set");
     }
-    changeOutputIndex = tx.outputs.size();
-    return addOutput(output, data);
+    if (output.capacity != 0) {
+      throw new IllegalArgumentException("Change output capacity is not 0");
+    }
+    changeOutput = output;
+    changeOutputData = data;
+    return this;
   }
 
   /**
-   * Set change output. Its capacity will be overwritten later when building the transaction.
+   * Set possible change output address.
    * <p>
    * Change output should be set only once.
    */
-  public CkbTransactionBuilder setChangeOutput(String address) {
+  public CkbTransactionBuilder setChangeOutput(@Nonnull String address) {
     CellOutput output = new CellOutput(0, Address.decode(address).getScript());
     return setChangeOutput(output, new byte[0]);
   }
 
   /**
+   * Returns a clone of tx with the change output added.
+   */
+  private Transaction txWithChangeOutput() {
+    List<CellOutput> outputs1 = Stream.concat(tx.outputs.stream(), Stream.of(changeOutput)).collect(Collectors.toList());
+    List<byte[]> outputsData1 = Stream.concat(tx.outputsData.stream(), Stream.of(changeOutputData)).collect(Collectors.toList());
+    return new Transaction(
+        tx.version,
+        tx.cellDeps,
+        tx.headerDeps,
+        tx.inputs,
+        outputs1,
+        outputsData1,
+        tx.witnesses
+    );
+  }
+
+  /**
    * Build the transaction. This will collect inputs so that there's enough capacity for the outputs.
+   * <p>
+   * If changeOutput is set, a change output will be added, unless forceSmallChangeAsFee is set and the change is small enough.
+   * </p>
+   * <p>
+   * If changeOutput is not set, forceSmallChangeAsFee must be set and the change must be small enough.
+   * </p>
+   *
+   * @throws IllegalStateException if settings are invalid or the transaction cannot be balanced.
    */
   @Override
   public TransactionWithScriptGroups build(Object... contexts) {
+    if (getConfiguration().getForceSmallChangeAsFee() == null && changeOutput == null) {
+      throw new IllegalStateException("Neither forceSmallChangeAsFee or changeOutput are set");
+    }
+
     Map<Script, ScriptGroup> scriptGroupMap = new HashMap<>();
     long outputsCapacity = 0L;
     for (int i = 0; i < tx.outputs.size(); i++) {
@@ -143,28 +182,27 @@ public class CkbTransactionBuilder extends AbstractTransactionBuilder {
       }
 
       inputsCapacity += input.output.capacity;
-      // check if there is enough capacity for output capacity and change
-      long fee = calculateTxFee(tx, configuration.getFeeRate());
-      long changeCapacity = inputsCapacity - outputsCapacity - fee + reward;
       final Long forceSmallChangeAsFee = getConfiguration().getForceSmallChangeAsFee();
-      if (forceSmallChangeAsFee != null && changeCapacity > 0 && changeCapacity < forceSmallChangeAsFee) {
-        if (changeOutputIndex != -1) {
-          throw new IllegalStateException("Will discard change capacity but change output is set");
+      if (forceSmallChangeAsFee != null) {
+        long fee = calculateTxFee(tx, configuration.getFeeRate());
+        long changeCapacity = inputsCapacity - outputsCapacity - fee + reward;
+        if (changeCapacity > 0 && changeCapacity < forceSmallChangeAsFee) {
+          enoughCapacity = true;
+          break;
         }
-        enoughCapacity = true;
-        break;
       }
-      if (changeCapacity > 0) {
-        try {
-          CellOutput changeOutput = tx.outputs.get(changeOutputIndex);
-          byte[] changeOutputData = tx.outputsData.get(changeOutputIndex);
-          if (changeCapacity >= changeOutput.occupiedCapacity(changeOutputData)) {
-            tx.outputs.get(changeOutputIndex).capacity = changeCapacity;
-            enoughCapacity = true;
-            break;
-          }
-        } catch (IndexOutOfBoundsException e) {
-          throw new IllegalStateException("Change output not set");
+
+      if (changeOutput != null) {
+        // Calculate fee with change output.
+        Transaction txWithChange = txWithChangeOutput();
+        long fee = calculateTxFee(txWithChange, configuration.getFeeRate());
+        long changeCapacity = inputsCapacity - outputsCapacity - fee + reward;
+        if (changeCapacity >= changeOutput.occupiedCapacity(changeOutputData)) {
+          changeOutput.capacity = changeCapacity;
+          // Replace tx with txWithChange.
+          tx = txWithChange;
+          enoughCapacity = true;
+          break;
         }
       }
     }
@@ -190,13 +228,12 @@ public class CkbTransactionBuilder extends AbstractTransactionBuilder {
           for (Object context : configuration.getScriptHandlers()) {
             if (handler.postBuild(idx, this, context)) {
               break;
-            };
+            }
           }
         }
       }
     }
   }
-  int transactionInputsIndex = 0;
 
   public TransactionInput next() {
     if (transactionInputsIndex < transactionInputs.size()) {
@@ -222,9 +259,6 @@ public class CkbTransactionBuilder extends AbstractTransactionBuilder {
       }
     }
     // only pool tx fee by null-type input
-    if (input.output.type != null) {
-      return true;
-    }
-    return false;
+    return input.output.type != null;
   }
 }

--- a/ckb/src/main/java/org/nervos/ckb/transaction/CkbTransactionBuilder.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/CkbTransactionBuilder.java
@@ -186,7 +186,7 @@ public class CkbTransactionBuilder extends AbstractTransactionBuilder {
       if (forceSmallChangeAsFee != null) {
         long fee = calculateTxFee(tx, configuration.getFeeRate());
         long changeCapacity = inputsCapacity - outputsCapacity - fee + reward;
-        if (changeCapacity > 0 && changeCapacity < forceSmallChangeAsFee) {
+        if (changeCapacity > 0 && changeCapacity <= forceSmallChangeAsFee) {
           enoughCapacity = true;
           break;
         }

--- a/ckb/src/main/java/org/nervos/ckb/transaction/SudtTransactionBuilder.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/SudtTransactionBuilder.java
@@ -6,7 +6,6 @@ import org.nervos.ckb.sign.TransactionWithScriptGroups;
 import org.nervos.ckb.transaction.handler.ScriptHandler;
 import org.nervos.ckb.type.CellOutput;
 import org.nervos.ckb.type.Script;
-import org.nervos.ckb.type.ScriptType;
 import org.nervos.ckb.type.TransactionInput;
 import org.nervos.ckb.utils.address.Address;
 
@@ -19,6 +18,8 @@ import static org.nervos.ckb.utils.AmountUtils.sudtAmountToData;
 public class SudtTransactionBuilder extends AbstractTransactionBuilder {
   private TransactionType transactionType;
   private Script sudtTypeScript;
+
+  private int changeOutputIndex = -1;
 
   public enum TransactionType {
     ISSUE,

--- a/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
@@ -3,6 +3,7 @@ package org.nervos.ckb.transaction;
 import org.nervos.ckb.Network;
 import org.nervos.ckb.transaction.handler.*;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -11,6 +12,8 @@ public class TransactionBuilderConfiguration {
   private Network network;
   private List<ScriptHandler> scriptHandlers = new ArrayList<>();
   private long feeRate = 1000;
+  @Nullable
+  private Long forceSmallChangeAsFee;
 
   public TransactionBuilderConfiguration() {
   }
@@ -62,5 +65,19 @@ public class TransactionBuilderConfiguration {
 
   public void setFeeRate(long feeRate) {
     this.feeRate = feeRate;
+  }
+
+  @Nullable
+  public Long getForceSmallChangeAsFee() {
+    return forceSmallChangeAsFee;
+  }
+
+  /**
+   * Set forceSmallChangeAsFee. When building transaction, a change output will not be required if it would be smaller than the specified amount.
+   *
+   * @param forceSmallChangeAsFee Unit shannons
+   */
+  public void setForceSmallChangeAsFee(@Nullable Long forceSmallChangeAsFee) {
+    this.forceSmallChangeAsFee = forceSmallChangeAsFee;
   }
 }

--- a/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
@@ -73,11 +73,17 @@ public class TransactionBuilderConfiguration {
   }
 
   /**
-   * Set forceSmallChangeAsFee. When building transaction, a change output will not be required if it would be smaller than the specified amount.
+   * Set forceSmallChangeAsFee. When building transaction, a change output will not be required if its capacity would be
+   * smaller than the specified amount.
    *
-   * @param forceSmallChangeAsFee Unit shannons
+   * @param forceSmallChangeAsFee Should be positive. Unit is shannons.
    */
   public void setForceSmallChangeAsFee(@Nullable Long forceSmallChangeAsFee) {
+    if (forceSmallChangeAsFee != null) {
+      if (forceSmallChangeAsFee <= 0) {
+        throw new IllegalArgumentException("invalid forceSmallChangeAsFee: " + forceSmallChangeAsFee);
+      }
+    }
     this.forceSmallChangeAsFee = forceSmallChangeAsFee;
   }
 }

--- a/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
@@ -74,7 +74,7 @@ public class TransactionBuilderConfiguration {
 
   /**
    * Set forceSmallChangeAsFee. When building transaction, a change output will not be required if its capacity would be
-   * smaller than the specified amount.
+   * smaller than or equal to the specified amount.
    *
    * @param forceSmallChangeAsFee Should be positive. Unit is shannons.
    */

--- a/core/src/main/java/org/nervos/ckb/utils/address/Address.java
+++ b/core/src/main/java/org/nervos/ckb/utils/address/Address.java
@@ -3,6 +3,7 @@ package org.nervos.ckb.utils.address;
 import org.nervos.ckb.Network;
 import org.nervos.ckb.type.Script;
 
+import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 import java.util.Objects;
@@ -40,7 +41,7 @@ public class Address {
 
   }
 
-  public static Address decode(String address) {
+  public static Address decode(@Nonnull String address) {
     Objects.requireNonNull(address);
     Bech32.Bech32Data bech32Data = Bech32.decode(address);
     Bech32.Encoding encoding = bech32Data.encoding;


### PR DESCRIPTION
~Due to existing design/implementation of change output, a change output must not be set when using this feature.~

~Alternatively, we can change the change output implementation a bit and still add a change output when this option is used but the fee is not that small. WDYT?~

Change output is still supported when using forceSmallChangeAsFee.