### PR TITLE
[BREAKING CHANGE] Add `MultisigVersion` `Legacy` and `V2`

### DIFF
--- a/ckb/src/main/java/org/nervos/ckb/CkbRpcApi.java
+++ b/ckb/src/main/java/org/nervos/ckb/CkbRpcApi.java
@@ -111,9 +111,9 @@ public interface CkbRpcApi {
   byte[] sendTestTransaction(Transaction transaction, OutputsValidator outputsValidator)
       throws IOException;
 	
-  byte[] testTxPoolAccept(Transaction transaction) throws IOException;
+  EntryCompleted testTxPoolAccept(Transaction transaction) throws IOException;
 
-  byte[] testTxPoolAccept(Transaction transaction, OutputsValidator outputsValidator)
+  EntryCompleted testTxPoolAccept(Transaction transaction, OutputsValidator outputsValidator)
       throws IOException;
 
   NodeInfo localNodeInfo() throws IOException;

--- a/ckb/src/main/java/org/nervos/ckb/service/Api.java
+++ b/ckb/src/main/java/org/nervos/ckb/service/Api.java
@@ -315,7 +315,7 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public byte[] testTxPoolAccept(Transaction transaction) throws IOException {
+  public EntryCompleted testTxPoolAccept(Transaction transaction) throws IOException {
     return rpcService.post(
         "test_tx_pool_accept",
         Arrays.asList(Convert.parseTransaction(transaction), OutputsValidator.PASSTHROUGH),
@@ -323,12 +323,12 @@ public class Api implements CkbRpcApi {
   }
 
   @Override
-  public byte[] testTxPoolAccept(Transaction transaction, OutputsValidator outputsValidator)
+  public EntryCompleted testTxPoolAccept(Transaction transaction, OutputsValidator outputsValidator)
       throws IOException {
     return rpcService.post(
         "test_tx_pool_accept",
         Arrays.asList(Convert.parseTransaction(transaction), outputsValidator),
-        byte[].class);
+        EntryCompleted.class);
   }
 
   @Override

--- a/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
@@ -2,6 +2,7 @@ package org.nervos.ckb.transaction;
 
 import org.nervos.ckb.Network;
 import org.nervos.ckb.transaction.handler.*;
+import org.nervos.ckb.type.MultisigVersion;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -22,7 +23,8 @@ public class TransactionBuilderConfiguration {
     Objects.requireNonNull(network);
     this.network = network;
     registerScriptHandler(Secp256k1Blake160SighashAllScriptHandler.class);
-    registerScriptHandler(Secp256k1Blake160MultisigAllScriptHandler.class);
+    registerScriptHandler(new Secp256k1Blake160MultisigAllScriptHandler(MultisigVersion.Legacy).getClass());
+    registerScriptHandler(new Secp256k1Blake160MultisigAllScriptHandler(MultisigVersion.V2).getClass());
     registerScriptHandler(SudtScriptHandler.class);
     registerScriptHandler(DaoScriptHandler.class);
     registerScriptHandler(OmnilockScriptHandler.class);

--- a/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
+++ b/ckb/src/main/java/org/nervos/ckb/transaction/TransactionBuilderConfiguration.java
@@ -23,8 +23,7 @@ public class TransactionBuilderConfiguration {
     Objects.requireNonNull(network);
     this.network = network;
     registerScriptHandler(Secp256k1Blake160SighashAllScriptHandler.class);
-    registerScriptHandler(new Secp256k1Blake160MultisigAllScriptHandler(MultisigVersion.Legacy).getClass());
-    registerScriptHandler(new Secp256k1Blake160MultisigAllScriptHandler(MultisigVersion.V2).getClass());
+    registerScriptHandler(Secp256k1Blake160MultisigAllScriptHandler.class);
     registerScriptHandler(SudtScriptHandler.class);
     registerScriptHandler(DaoScriptHandler.class);
     registerScriptHandler(OmnilockScriptHandler.class);

--- a/core/src/main/java/org/nervos/ckb/sign/TransactionSigner.java
+++ b/core/src/main/java/org/nervos/ckb/sign/TransactionSigner.java
@@ -19,7 +19,9 @@ public class TransactionSigner {
         .registerLockScriptSigner(
             Script.SECP256K1_BLAKE160_SIGNHASH_ALL_CODE_HASH, new Secp256k1Blake160SighashAllSigner())
         .registerLockScriptSigner(
-            Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH, new Secp256k1Blake160MultisigAllSigner())
+            Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY, new Secp256k1Blake160MultisigAllSigner())
+        .registerLockScriptSigner(
+            Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_V2, new Secp256k1Blake160MultisigAllSigner())
         .registerLockScriptSigner(
             Script.ANY_CAN_PAY_CODE_HASH_TESTNET, new AcpSigner())
         .registerLockScriptSigner(
@@ -31,7 +33,9 @@ public class TransactionSigner {
         .registerLockScriptSigner(
             Script.SECP256K1_BLAKE160_SIGNHASH_ALL_CODE_HASH, new Secp256k1Blake160SighashAllSigner())
         .registerLockScriptSigner(
-            Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH, new Secp256k1Blake160MultisigAllSigner())
+            Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY, new Secp256k1Blake160MultisigAllSigner())
+        .registerLockScriptSigner(
+            Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_V2, new Secp256k1Blake160MultisigAllSigner())
         .registerLockScriptSigner(
             Script.ANY_CAN_PAY_CODE_HASH_MAINNET, new AcpSigner())
         .registerLockScriptSigner(

--- a/core/src/main/java/org/nervos/ckb/sign/TransactionSigner.java
+++ b/core/src/main/java/org/nervos/ckb/sign/TransactionSigner.java
@@ -20,7 +20,7 @@ public class TransactionSigner {
             Script.SECP256K1_BLAKE160_SIGNHASH_ALL_CODE_HASH, new Secp256k1Blake160SighashAllSigner())
         .registerLockScriptSigner(
             Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY, new Secp256k1Blake160MultisigAllSigner())
-        .registerLockScriptSigner(
+        .registerLockScriptData1Signer(
             Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_V2, new Secp256k1Blake160MultisigAllSigner())
         .registerLockScriptSigner(
             Script.ANY_CAN_PAY_CODE_HASH_TESTNET, new AcpSigner())
@@ -34,7 +34,7 @@ public class TransactionSigner {
             Script.SECP256K1_BLAKE160_SIGNHASH_ALL_CODE_HASH, new Secp256k1Blake160SighashAllSigner())
         .registerLockScriptSigner(
             Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY, new Secp256k1Blake160MultisigAllSigner())
-        .registerLockScriptSigner(
+        .registerLockScriptData1Signer(
             Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_V2, new Secp256k1Blake160MultisigAllSigner())
         .registerLockScriptSigner(
             Script.ANY_CAN_PAY_CODE_HASH_MAINNET, new AcpSigner())
@@ -85,6 +85,10 @@ public class TransactionSigner {
 
   public TransactionSigner registerLockScriptSigner(byte[] codeHash, ScriptSigner scriptSigner) {
     return register(codeHash, Script.HashType.TYPE, ScriptType.LOCK, scriptSigner);
+  }
+
+  public TransactionSigner registerLockScriptData1Signer(byte[] codeHash, ScriptSigner scriptSigner) {
+    return register(codeHash, Script.HashType.DATA1, ScriptType.LOCK, scriptSigner);
   }
 
   public TransactionSigner registerLockScriptSigner(String codeHash, ScriptSigner scriptSigner) {

--- a/core/src/main/java/org/nervos/ckb/type/EntryCompleted.java
+++ b/core/src/main/java/org/nervos/ckb/type/EntryCompleted.java
@@ -1,0 +1,6 @@
+package org.nervos.ckb.type;
+
+public class EntryCompleted {
+    public long cycles;
+    public long fee;
+}

--- a/core/src/main/java/org/nervos/ckb/type/MultisigVersion.java
+++ b/core/src/main/java/org/nervos/ckb/type/MultisigVersion.java
@@ -1,0 +1,35 @@
+package org.nervos.ckb.type;
+
+public enum MultisigVersion {
+  /// Multisig Script deployed on Genesis Block
+  /// https://explorer.nervos.org/script/0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8/type
+  Legacy,
+  /// Latest multisig script, Enhance multisig handling for optional since value
+  /// https://github.com/nervosnetwork/ckb-system-scripts/pull/99
+  /// https://explorer.nervos.org/script/0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29/data1
+  V2;
+
+  public byte[] codeHash(){
+    switch (this)
+    {
+      case Legacy:
+        return Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY;
+      case V2:
+        return Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_V2;
+      default:
+        throw new IllegalArgumentException("Unknown multisig version: " + this);
+    }
+  }
+  
+  public Script.HashType hashType() {
+    switch (this)
+    {
+      case Legacy:
+        return Script.HashType.TYPE;
+      case V2:
+        return Script.HashType.DATA1;
+      default:
+        throw new IllegalArgumentException("Unknown multisig version: " + this);
+    }
+  }
+}

--- a/core/src/main/java/org/nervos/ckb/type/Script.java
+++ b/core/src/main/java/org/nervos/ckb/type/Script.java
@@ -11,11 +11,19 @@ import java.util.Arrays;
 import static org.nervos.ckb.utils.MoleculeConverter.packByte32;
 import static org.nervos.ckb.utils.MoleculeConverter.packBytes;
 
+
 public class Script {
   public static final byte[] SECP256K1_BLAKE160_SIGNHASH_ALL_CODE_HASH =
       Numeric.hexStringToByteArray("0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8");
-  public static final byte[] SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH =
+  // Multisig Script deployed on Genesis Block
+  // https://explorer.nervos.org/script/0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8/type
+  public static final byte[] SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY =
       Numeric.hexStringToByteArray("0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8");
+  // Latest multisig script, Enhance multisig handling for optional since value
+  // https://github.com/nervosnetwork/ckb-system-scripts/pull/99
+  // https://explorer.nervos.org/script/0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29/data1
+  public static final byte[] SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_V2=
+      Numeric.hexStringToByteArray("0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29");
   public static final byte[] ANY_CAN_PAY_CODE_HASH_MAINNET =
       Numeric.hexStringToByteArray("0xd369597ff47f29fbc0d47d2e3775370d1250b85140c670e4718af712983a2354");
   public static final byte[] ANY_CAN_PAY_CODE_HASH_TESTNET =

--- a/core/src/main/java/org/nervos/ckb/utils/address/Address.java
+++ b/core/src/main/java/org/nervos/ckb/utils/address/Address.java
@@ -85,7 +85,7 @@ public class Address {
       if (args.length != 20) {
         throw new AddressFormatException("Invalid args length " + args.length);
       }
-      codeHash = Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH;
+      codeHash = Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY;
     } else if (codeHashIndex == 0x02) {
       if (args.length < 20 || args.length > 22) {
         throw new AddressFormatException("Invalid args length " + args.length);
@@ -145,7 +145,7 @@ public class Address {
     byte[] codeHash = script.codeHash;
     if (Arrays.equals(codeHash, Script.SECP256K1_BLAKE160_SIGNHASH_ALL_CODE_HASH)) {
       codeHashIndex = 0x00;
-    } else if (Arrays.equals(codeHash, Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH)) {
+    } else if (Arrays.equals(codeHash, Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY)) {
       codeHashIndex = 0x01;
     } else if ((network == Network.MAINNET && Arrays.equals(codeHash, Script.ANY_CAN_PAY_CODE_HASH_MAINNET)
         || (network == Network.TESTNET && Arrays.equals(codeHash, Script.ANY_CAN_PAY_CODE_HASH_TESTNET)))) {

--- a/core/src/test/java/utils/AddressTest.java
+++ b/core/src/test/java/utils/AddressTest.java
@@ -2,6 +2,7 @@ package utils;
 
 import org.junit.jupiter.api.Test;
 import org.nervos.ckb.Network;
+import org.nervos.ckb.type.MultisigVersion;
 import org.nervos.ckb.type.Script;
 import org.nervos.ckb.utils.Numeric;
 import org.nervos.ckb.utils.address.Address;
@@ -22,7 +23,7 @@ public class AddressTest {
     testShort(script, Network.MAINNET, "ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v");
     testShort(script, Network.TESTNET, "ckt1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jq5t63cs");
 
-    script = generateScript(Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH,
+    script = generateScript(Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH_LEGACY,
                             "4fb2be2e5d0c1a3b8694f832350a33c1685d477a", Script.HashType.TYPE);
     testShort(script, Network.MAINNET, "ckb1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqklhtgg");
     testShort(script, Network.TESTNET, "ckt1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqt6f5y5");
@@ -59,6 +60,18 @@ public class AddressTest {
                             "b39bbc0b3673c7d36450bc14cfcdad2d559c6c64", Script.HashType.DATA1);
     testFullBech32m(script, Network.MAINNET, "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqcydzyt");
     testFullBech32m(script, Network.TESTNET, "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqkkxdwn");
+
+    // multiscript v2
+
+    script = generateScript(MultisigVersion.V2.codeHash(),
+                            "986b5c23988427044e57d188fee45530d8877bcc", MultisigVersion.V2.hashType());
+    testFullBech32m(script, Network.MAINNET, "ckb1qqmvjudc6s0mm992hjnhm367sfnjntycg3a5d7g7qpukz4wamvxjjq5cddwz8xyyyuzyu4733rlwg4fsmzrhhnqvclulh");
+    testFullBech32m(script, Network.TESTNET, "ckt1qqmvjudc6s0mm992hjnhm367sfnjntycg3a5d7g7qpukz4wamvxjjq5cddwz8xyyyuzyu4733rlwg4fsmzrhhnqz25n40");
+
+    script = generateScript(MultisigVersion.Legacy.codeHash(),
+                            "986b5c23988427044e57d188fee45530d8877bcc", MultisigVersion.Legacy.hashType());
+    testFullBech32m(script, Network.MAINNET, "ckb1qpw9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn32sqvcddwz8xyyyuzyu4733rlwg4fsmzrhhnqq5gm75");
+    testFullBech32m(script, Network.TESTNET, "ckt1qpw9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn32sqvcddwz8xyyyuzyu4733rlwg4fsmzrhhnqwxr55v");
   }
 
   private void testShort(Script script, Network network, String encoded) {

--- a/example/src/main/java/org/nervos/ckb/example/SendCkbMultisigExample.java
+++ b/example/src/main/java/org/nervos/ckb/example/SendCkbMultisigExample.java
@@ -8,9 +8,7 @@ import org.nervos.ckb.sign.TransactionWithScriptGroups;
 import org.nervos.ckb.sign.signer.Secp256k1Blake160MultisigAllSigner;
 import org.nervos.ckb.transaction.CkbTransactionBuilder;
 import org.nervos.ckb.transaction.TransactionBuilderConfiguration;
-import org.nervos.ckb.type.MultisigVersion;
-import org.nervos.ckb.type.Script;
-import org.nervos.ckb.type.TransactionInput;
+import org.nervos.ckb.type.*;
 import org.nervos.ckb.utils.Numeric;
 import org.nervos.ckb.utils.address.Address;
 import org.nervos.ckb.transaction.InputIterator;
@@ -44,7 +42,7 @@ public class SendCkbMultisigExample {
     signer.signTransaction(txWithGroups, new Context("0x4fd809631a6aa6e3bb378dd65eae5d71df895a82c91a615a1e8264741515c79c", multisigScript));
     signer.signTransaction(txWithGroups, new Context("0x7438f7b35c355e3d2fb9305167a31a72d22ddeafb80a21cc99ff6329d92e8087", multisigScript));
 
-    Api api = new Api("https://testnet.ckb.dev", false);
+    Api api = new Api("https://testnet.ckb.dev", true);
     byte[] txHash = api.sendTransaction(txWithGroups.getTxView());
     System.out.println("Transaction hash: " + Numeric.toHexString(txHash));
   }
@@ -61,7 +59,7 @@ public class SendCkbMultisigExample {
         multisigScript.computeHash(),
         MultisigVersion.V2.hashType()
     );
-    // ckt1qpw9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn32sqdunqvd3g2felqv6qer8pkydws8jg9qxlca0st5v
+    // ckt1qqmvjudc6s0mm992hjnhm367sfnjntycg3a5d7g7qpukz4wamvxjjq4unqvd3g2felqv6qer8pkydws8jg9qxlc3r8v40
     String sender = new Address(lock, network).encode();
 
     TransactionBuilderConfiguration configuration = new TransactionBuilderConfiguration(network);
@@ -76,13 +74,14 @@ public class SendCkbMultisigExample {
     signer.signTransaction(txWithGroups, new Context("0x4fd809631a6aa6e3bb378dd65eae5d71df895a82c91a615a1e8264741515c79c", multisigScript));
     signer.signTransaction(txWithGroups, new Context("0x7438f7b35c355e3d2fb9305167a31a72d22ddeafb80a21cc99ff6329d92e8087", multisigScript));
 
-    Api api = new Api("https://testnet.ckb.dev", false);
+    Api api = new Api("https://testnet.ckb.dev", true);
+//    EntryCompleted completed = api.testTxPoolAccept(txWithGroups.getTxView(), OutputsValidator.PASSTHROUGH);
     byte[] txHash = api.sendTransaction(txWithGroups.getTxView());
     System.out.println("Transaction hash: " + Numeric.toHexString(txHash));
   }
 
   public static void main(String[] args) throws IOException {
-    example_legacy();
+//    example_legacy();
     example_v2();
   }
 }

--- a/example/src/main/java/org/nervos/ckb/example/SendCkbMultisigExample.java
+++ b/example/src/main/java/org/nervos/ckb/example/SendCkbMultisigExample.java
@@ -8,6 +8,7 @@ import org.nervos.ckb.sign.TransactionWithScriptGroups;
 import org.nervos.ckb.sign.signer.Secp256k1Blake160MultisigAllSigner;
 import org.nervos.ckb.transaction.CkbTransactionBuilder;
 import org.nervos.ckb.transaction.TransactionBuilderConfiguration;
+import org.nervos.ckb.type.MultisigVersion;
 import org.nervos.ckb.type.Script;
 import org.nervos.ckb.type.TransactionInput;
 import org.nervos.ckb.utils.Numeric;
@@ -18,16 +19,16 @@ import java.io.IOException;
 import java.util.Iterator;
 
 public class SendCkbMultisigExample {
-  public static void main(String[] args) throws IOException {
+  public static void example_legacy() throws IOException {
     Network network = Network.TESTNET;
     Secp256k1Blake160MultisigAllSigner.MultisigScript multisigScript =
         new Secp256k1Blake160MultisigAllSigner.MultisigScript(0, 2,
                                                               "0x7336b0ba900684cb3cb00f0d46d4f64c0994a562",
                                                               "0x5724c1e3925a5206944d753a6f3edaedf977d77f");
     Script lock = new Script(
-        Script.SECP256K1_BLAKE160_MULTISIG_ALL_CODE_HASH,
+        MultisigVersion.Legacy.codeHash(),
         multisigScript.computeHash(),
-        Script.HashType.TYPE);
+        MultisigVersion.Legacy.hashType());
     // ckt1qpw9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn32sqdunqvd3g2felqv6qer8pkydws8jg9qxlca0st5v
     String sender = new Address(lock, network).encode();
 
@@ -46,5 +47,42 @@ public class SendCkbMultisigExample {
     Api api = new Api("https://testnet.ckb.dev", false);
     byte[] txHash = api.sendTransaction(txWithGroups.getTxView());
     System.out.println("Transaction hash: " + Numeric.toHexString(txHash));
+  }
+
+
+  public static void example_v2() throws IOException {
+    Network network = Network.TESTNET;
+    Secp256k1Blake160MultisigAllSigner.MultisigScript multisigScript =
+        new Secp256k1Blake160MultisigAllSigner.MultisigScript(0, 2,
+                                                              "0x7336b0ba900684cb3cb00f0d46d4f64c0994a562",
+                                                              "0x5724c1e3925a5206944d753a6f3edaedf977d77f");
+    Script lock = new Script(
+        MultisigVersion.V2.codeHash(),
+        multisigScript.computeHash(),
+        MultisigVersion.V2.hashType()
+    );
+    // ckt1qpw9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn32sqdunqvd3g2felqv6qer8pkydws8jg9qxlca0st5v
+    String sender = new Address(lock, network).encode();
+
+    TransactionBuilderConfiguration configuration = new TransactionBuilderConfiguration(network);
+    Iterator<TransactionInput> iterator = new InputIterator(sender);
+    TransactionWithScriptGroups txWithGroups = new CkbTransactionBuilder(configuration, iterator)
+        .addOutput("ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq2qf8keemy2p5uu0g0gn8cd4ju23s5269qk8rg4r",
+                   50100000001L)
+        .setChangeOutput(sender)
+        .build(multisigScript);
+
+    TransactionSigner signer = TransactionSigner.getInstance(network);
+    signer.signTransaction(txWithGroups, new Context("0x4fd809631a6aa6e3bb378dd65eae5d71df895a82c91a615a1e8264741515c79c", multisigScript));
+    signer.signTransaction(txWithGroups, new Context("0x7438f7b35c355e3d2fb9305167a31a72d22ddeafb80a21cc99ff6329d92e8087", multisigScript));
+
+    Api api = new Api("https://testnet.ckb.dev", false);
+    byte[] txHash = api.sendTransaction(txWithGroups.getTxView());
+    System.out.println("Transaction hash: " + Numeric.toHexString(txHash));
+  }
+
+  public static void main(String[] args) throws IOException {
+    example_legacy();
+    example_v2();
   }
 }


### PR DESCRIPTION
This PR add `MultisigVersion` to ckb-sdk-java:
before
```java
Secp256k1Blake160MultisigAllScriptHandler handler = Secp256k1Blake160MultisigAllScriptHandler();
handler.init();
```
This PR:
```java
public enum MultisigVersion {
  /// Multisig Script deployed on Genesis Block
  /// https://explorer.nervos.org/script/0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8/type
  Legacy,
  /// Latest multisig script, Enhance multisig handling for optional since value
  /// https://github.com/nervosnetwork/ckb-system-scripts/pull/99
  /// https://explorer.nervos.org/script/0x36c971b8d41fbd94aabca77dc75e826729ac98447b46f91e00796155dddb0d29/data1
  V2;


Secp256k1Blake160MultisigAllScriptHandler handler = Secp256k1Blake160MultisigAllScriptHandler(MultisigVersion::Legacy);
handler.init();
```

Invite @doitian, @zhangsoledad, @driftluo , @quake to review.